### PR TITLE
Blank line fix

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -35,7 +35,6 @@ function dotenv() {
           process.env[key]    = value;
         }
       } catch (e) {
-        console.log(e)
       }
 
       return true;


### PR DESCRIPTION
dotenv was crashing if I had a blank line in my .env file. This should resolve that.
