### PR TITLE
respect equals signs in values

### DIFF
--- a/.env
+++ b/.env
@@ -5,3 +5,4 @@ EXPAND_NEWLINES="expand\nnewlines"
 DONT_EXPAND_NEWLINES_1=dontexpand\nnewlines
 DONT_EXPAND_NEWLINES_2='dontexpand\nnewlines'
 ENVIRONMENT_OVERRIDE=production
+EQUAL_SIGNS=equals==

--- a/lib/main.js
+++ b/lib/main.js
@@ -16,16 +16,16 @@ function dotenv() {
       return dotenv._getKeysAndValuesFromEnvFilePath(".env."+dotenv.environment);
     },
     _getKeyAndValueFromLine: function(line) {
-      var key_value_array = line.split("=");
-      var key             = key_value_array[0].trim();
-      var value           = key_value_array[1].trim();
+      var key_value_array = line.match(/^\s*([\w\.\-\_]+)\s*=\s*(.*?)\s*$/);
+      var key             = key_value_array[1].trim();
+      var value           = key_value_array[2].trim();
 
       if (value.charAt(0) === '"' && value.charAt(value.length-1) == '"') {
         value             = value.replace(/\\n/gm, "\n");
       }
       value               = value.replace(/['"]/gm, '');
 
-      return [key, value]
+      return [key, value];
     },
     _getKeysAndValuesFromEnvFilePath: function(filepath) {
       try {
@@ -38,7 +38,7 @@ function dotenv() {
           var array = dotenv._getKeyAndValueFromLine(lines[i]);
           var key   = array[0];
           var value = array[1];
- 
+
           dotenv.keys_and_values[key] = value;
         }
       } catch (e) {

--- a/test/main.js
+++ b/test/main.js
@@ -48,6 +48,10 @@ describe('dotenv', function() {
       process.env.AFTER_LINE.should.eql("after_line");
     });
 
+    it('respects equals signs in values', function() {
+      process.env.EQUAL_SIGNS.should.eql("equals==");
+    });
+
   });
 
   describe('.load() after an ENV was already set on the machine', function() {


### PR DESCRIPTION
I came across an issue trying to use an API key with equals signs in it. This regex approach respects them. Tests included.
