### PR TITLE
Simple feature to specify the filename to overwrite ".env" and to specify a directory

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -2,6 +2,7 @@
 
 var package_json  = require('./../package.json');
 var fs            = require('fs');
+var path          = require('path')
 
 function dotenv() {
   dotenv = {
@@ -9,11 +10,11 @@ function dotenv() {
     environment:      process.env.NODE_ENV || "development",
     keys_and_values:  {},
 
-    _loadEnv: function() {
-      return dotenv._getKeysAndValuesFromEnvFilePath(".env");
+    _loadEnv: function(file, directory) {
+      return dotenv._getKeysAndValuesFromEnvFilePath(path.resolve(directory, file || ".env"));
     },
-    _loadEnvDotEnvironment: function() {
-      return dotenv._getKeysAndValuesFromEnvFilePath(".env."+dotenv.environment);
+    _loadEnvDotEnvironment: function(file, directory) {
+      return dotenv._getKeysAndValuesFromEnvFilePath(path.resolve(directory, (file || ".env") + '.' + dotenv.environment));
     },
     _getKeyAndValueFromLine: function(line) {
       var key_value_array = line.match(/^\s*([\w\.\-\_]+)\s*=\s*(.*?)\s*$/);
@@ -58,9 +59,13 @@ function dotenv() {
         process.env[key]  = process.env[key] || value;
       });
     },
-    load: function() {
-      dotenv._loadEnv();
-      dotenv._loadEnvDotEnvironment();
+    load: function(options) {
+      var options           = (typeof options !== 'function') && options || {};
+          options.file      = options.file || null;
+          options.directory = options.directory ? path.normalize(options.directory || options.dir) : "";
+
+      dotenv._loadEnv(options.file, options.directory);
+      dotenv._loadEnvDotEnvironment(options.file, options.directory);
       dotenv._setEnvs();
 
       return true;


### PR DESCRIPTION
Example: load({ file: ".environment" , directory: "/home/bryanph/Viriciti/dotenv" })
Of course load() also still works
