### PR TITLE
added support for empty environment variables

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 BASIC=basic
+EMPTY=
 SINGLE_QUOTES='single_quotes'
 DOUBLE_QUOTES="double_quotes"
 EXPAND_NEWLINES="expand\nnewlines"

--- a/lib/main.js
+++ b/lib/main.js
@@ -23,6 +23,10 @@ function dotenv() {
       var key             = key_value_array[1];
       var value           = key_value_array[2];
 
+      if(typeof value === "undefined"){
+        value = "";
+      }
+
       if (value.charAt(0) === '"' && value.charAt(value.length-1) == '"') {
         value             = value.replace(/\\n/gm, "\n");
       }

--- a/test/main.js
+++ b/test/main.js
@@ -23,6 +23,10 @@ describe('dotenv', function() {
       process.env.BASIC.should.eql("basic");
     });
 
+    it('sets empty enviroment variable', function () {
+      process.env.EMPTY.should.eql("");
+    });
+
     it('sets double quotes environment variables', function() {
       process.env.DOUBLE_QUOTES.should.eql("double_quotes");
     });


### PR DESCRIPTION
The current version runs into a TypeError when a variable is left empty. The ruby version allows for empty variables and just loads them as empty strings.

I think this is useful, as authors of apps may want to include a full sample `.env` in their repo. As a user, I may only fill in a couple values, but want to save the rest for the future.

This pull request brings this behavior in line with the ruby library and adds test for the added functionality.

Please let me know your thoughts, or if there's anything I can do.
