### PR TITLE
Added support for environment variables containing quotes

### DIFF
--- a/.env
+++ b/.env
@@ -10,3 +10,4 @@ ENVIRONMENT_OVERRIDE=production
 # COMMENTS=work
 EQUAL_SIGNS=equals==
 ZERO_WIDTH_CHARACTER=​user:pass@troup.mongohq.com:1004/dude
+RETAIN_INNER_QUOTES='{"foo": "bar"}'

--- a/lib/main.js
+++ b/lib/main.js
@@ -31,7 +31,7 @@ function dotenv() {
       if (value.charAt(0) === '"' && value.charAt(value.length-1) == '"') {
         value             = value.replace(/\\n/gm, "\n");
       }
-      value               = value.replace(/['"]/gm, '');
+      value               = value.replace(/(^['"]|['"]$)/g, ''); // replace first and last quotes only
 
       return [key, value];
     },

--- a/test/main.js
+++ b/test/main.js
@@ -64,6 +64,11 @@ describe('dotenv', function() {
     it('should handle zero width unicode characters', function() {
       process.env.ZERO_WIDTH_CHARACTER.should.eql("user:pass@troup.mongohq.com:1004/dude");
     });
+    
+    it ('retains inner quotes', function() {
+      process.env.RETAIN_INNER_QUOTES.should.eql('{"foo": "bar"}');
+    });
+
 
   });
 


### PR DESCRIPTION
This update allows you to use environment variables that contain quotes.
i.e.

```
MY_DATA={"foo": "bar"}
MY_MESSAGE="Why can't I use quotes?"
```
