### PR TITLE
Removed './node_modules/.bin/' because tests won't run on windows.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha test/*.js"
+    "test": "mocha test/*.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
`npm test` command will fail with 

> '.' is not recognized as an internal or external command, operable program or batch file.
> npm ERR! Test failed.  See above for more details.
> npm ERR! not ok code 0

and it is because of the test configuration in the package.json file. 
As you can read from https://github.com/npm/npm/issues/2576

> Get rid of the `node_modules/.bin/` bit.  It's unnecessary, since npm puts that in the PATH for test scripts already.

After making the changes I was able to run tests
