### PR TITLE
read .env.local for environment overrides

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,1 @@
+FROM_LOCAL_ENV=from_local_env

--- a/lib/main.js
+++ b/lib/main.js
@@ -16,6 +16,9 @@ function dotenv() {
     _loadEnvDotEnvironment: function() {
       return dotenv._getKeysAndValuesFromEnvFilePath(".env."+dotenv.environment());
     },
+    _loadEnvDotLocal: function() {
+      return dotenv._getKeysAndValuesFromEnvFilePath(".env.local");
+    },
     _getKeyAndValueFromLine: function(line) {
       var key_value_array = line.match(/^\s*([\w\.\-]+)\s*=\s*(.*)?\s*$/);
 
@@ -100,6 +103,7 @@ function dotenv() {
     load: function() {
       dotenv._loadEnv();
       dotenv._loadEnvDotEnvironment();
+      dotenv._loadEnvDotLocal();
       dotenv._setEnvs();
 
       return true;

--- a/test/main.js
+++ b/test/main.js
@@ -77,6 +77,10 @@ describe('dotenv', function() {
       process.env.ENVIRONMENT_OVERRIDE.should.eql("staging");
     });
 
+    it('reads from .env.local', function() {
+      process.env.FROM_LOCAL_ENV.should.eql("from_local_env");
+    });
+
     it('reads from a skipped line in .env.development', function() {
       process.env.AFTER_LINE.should.eql("after_line");
     });


### PR DESCRIPTION
The .env.local file is read last and provides a convenient workflow for environment overrides that will not be checked in to your repo (often being ignored via .gitignore).

A typical repo will have the following file setup:

`.env` baseline variables that are relevant for event situation
`.env.development` loaded by default if no NODE_ENV is specified (possibly omitted in favor of dev defaults living in .env)
`.env.local` never checked in and allows the developer to temporarily override env vars without the fear of checking in the changes.

When doing dev, I might temporarily change the redis server or some other env flag and want to make sure I don't check in this change. I would make this change in my .env.local file (or create one if it doesn't exist) and put the flag there. Git will ignore it and I won't check in my local only env.
