### PR TITLE
Add load.js

### DIFF
--- a/load.js
+++ b/load.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = require("./lib/main").load();


### PR DESCRIPTION
This change makes it easy to use dotenv from the command line with
modules that support the -r loading convention, e.g.

```
mocha -r dotenv/load my-test.js
```
