### PR TITLE
add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
I've noticed a lot of whitespace diffs in PRs lately. [Editorconfig](editorconfig.org) will help us define and maintain a consistent coding style.

I don't have any strong feelings towards the style, just as long as there is one and it's followed.
