### PR TITLE
Add dotenv.overload()

### DIFF
--- a/.env
+++ b/.env
@@ -16,3 +16,4 @@ EQUAL_SIGNS=equals==
 ZERO_WIDTH_CHARACTER=​user:pass@troup.mongohq.com:1004/dude
 RETAIN_INNER_QUOTES={"foo": "bar"}
 RETAIN_INNER_QUOTES_AS_STRING='{"foo": "bar"}'
+OVERLOAD_THIS_VAR='overloaded'

--- a/lib/main.js
+++ b/lib/main.js
@@ -76,11 +76,17 @@ function dotenv() {
 
       return true;
     },
-    _setEnvs: function() {
+    _setEnvs: function(overload) {
+      if (typeof overload === 'undefined') overload = false;
+
       Object.keys(dotenv.keys_and_values).forEach(function(key) {
         var value         = dotenv.keys_and_values[key];
 
-        process.env[key]  = process.env[key] || value;
+        if(overload) {
+          process.env[key]  = value;
+        } else {
+          process.env[key]  = process.env[key] || value;
+        }
       });
     },
     parse : function(data) {
@@ -97,13 +103,18 @@ function dotenv() {
       });
       return payload;
     },
-    load: function() {
+    load: function(overload) {
+      if (typeof overload === 'undefined') overload = false;
+
       if (dotenv._loadEnv() && dotenv._loadEnvDotEnvironment()) {
-        dotenv._setEnvs();
+        dotenv._setEnvs(overload);
         return true;
       } else {
         return false;
       }
+    },
+    overload: function() {
+      return dotenv.load(true);
     },
   };
 

--- a/test/main.js
+++ b/test/main.js
@@ -117,6 +117,18 @@ describe('dotenv', function() {
 
   });
 
+  describe('.overload', function() {
+    before(function () {
+      process.env.OVERLOAD_THIS_VAR = 'not overloaded';
+    });
+
+    it('overload a existing environment variable', function() {
+      process.env.OVERLOAD_THIS_VAR.should.eql('not overloaded');
+      result.overload();
+      process.env.OVERLOAD_THIS_VAR.should.eql('overloaded');
+    });
+  });
+
   describe('.load() after an ENV was already set on the machine', function() {
     before(function() {
       process.env.ENVIRONMENT_OVERRIDE = "set_on_machine";


### PR DESCRIPTION
Sometimes you need to overload a system environment variable. Then
use the dotenv.overload() function.

Example:
  Your system has a HTTP_PROXY environment variable already
  defined. And your application should not use a proxy to
  communicate with another application. Then you can set your .env
  file with a variable HTTP_PROXY='' to unset this proxy.

  Or you can overload whatever environment variable you want
  to.