### PR TITLE
add option to silence errors

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -11,6 +11,7 @@ module.exports = {
   config: function (options) {
     var path = '.env'
     var encoding = 'utf8'
+    var silent = false
 
     if (options) {
       if (options.path) {
@@ -18,6 +19,9 @@ module.exports = {
       }
       if (options.encoding) {
         encoding = options.encoding
+      }
+      if (options.silent) {
+        silent = options.silent
       }
     }
 
@@ -31,7 +35,9 @@ module.exports = {
 
       return true
     } catch(e) {
-      console.error(e)
+      if (!silent) {
+        console.error(e)
+      }
       return false
     }
   },

--- a/test/main.js
+++ b/test/main.js
@@ -83,6 +83,15 @@ describe('dotenv', function () {
       done()
     })
 
+    it('takes option for silencing errors', function (done) {
+      var errorStub = s.stub(console, 'error')
+      readFileSyncStub.throws()
+
+      dotenv.config({silent: true}).should.eql(false)
+      errorStub.called.should.be.false
+      done()
+    })
+
   })
 
   describe('parse', function () {


### PR DESCRIPTION
ref #58

add option to silence `console.log` when error occurs while reading and parsing files