### PR TITLE
add test that sets ENV to a string with spaces

### DIFF
--- a/test/.env
+++ b/test/.env
@@ -16,3 +16,4 @@ DONT_EXPAND_NEWLINES_2='dontexpand\nnewlines'
 EQUAL_SIGNS=equals==
 RETAIN_INNER_QUOTES={"foo": "bar"}
 RETAIN_INNER_QUOTES_AS_STRING='{"foo": "bar"}'
+INCLUDE_SPACE=some spaced out string

--- a/test/main.js
+++ b/test/main.js
@@ -195,5 +195,10 @@ describe('dotenv', function () {
       parsed.RETAIN_INNER_QUOTES_AS_STRING.should.eql('{\"foo\": \"bar\"}')
       done()
     })
+
+    it('retains spaces in string', function (done) {
+      parsed.INCLUDE_SPACE.should.eql('some spaced out string')
+      done()
+    })
   })
 })


### PR DESCRIPTION
looking at the test I was unsure if spaces would be included.
created a test to show that you can include spaces in the `.env` file