### PR TITLE
Added overwrite option

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -5,13 +5,14 @@ var fs = require('fs')
 module.exports = {
   /*
    * Main entry point into dotenv. Allows configuration before loading .env and .env.$NODE_ENV
-   * @param {Object} options - valid options: path ('.env'), encoding ('utf8')
+   * @param {Object} options - valid options: path ('.env'), encoding ('utf8'), overwrite (true)
    * @returns {Boolean}
   */
   config: function (options) {
     var path = '.env'
     var encoding = 'utf8'
     var silent = false
+    var overwrite = false
 
     if (options) {
       if (options.silent) {
@@ -23,15 +24,24 @@ module.exports = {
       if (options.encoding) {
         encoding = options.encoding
       }
+      if (options.overwrite) {
+        overwrite = options.overwrite
+      }
     }
 
     try {
       // specifying an encoding returns a string instead of a buffer
       var parsedObj = this.parse(fs.readFileSync(path, { encoding: encoding }))
 
-      Object.keys(parsedObj).forEach(function (key) {
-        process.env[key] = process.env[key] || parsedObj[key]
-      })
+      if (overwrite) {
+        Object.keys(parsedObj).forEach(function (key) {
+          process.env[key] = parsedObj[key]
+        })
+      } else {
+        Object.keys(parsedObj).forEach(function (key) {
+          process.env[key] = process.env[key] || parsedObj[key]
+        })
+      }
 
       return true
     } catch(e) {

--- a/test/main.js
+++ b/test/main.js
@@ -28,8 +28,8 @@ describe('dotenv', function () {
     var readFileSyncStub, parseStub
 
     beforeEach(function (done) {
-      readFileSyncStub = s.stub(fs, 'readFileSync').returns('test=val')
-      parseStub = s.stub(dotenv, 'parse').returns({test: 'val'})
+      readFileSyncStub = s.stub(fs, 'readFileSync').returns('TEST=val')
+      parseStub = s.stub(dotenv, 'parse').returns({TEST: 'val'})
       done()
     })
 
@@ -46,6 +46,15 @@ describe('dotenv', function () {
       dotenv.config({encoding: testEncoding})
 
       readFileSyncStub.args[0][1].should.have.property('encoding', testEncoding)
+      done()
+    })
+
+    it('takes option for overwrite', function (done) {
+      process.env.TEST = 'test'
+      // 'val' returned as value in `beforeEach`. should keep this 'test'
+      dotenv.config({overwrite: true})
+
+      process.env.TEST.should.eql('val')
       done()
     })
 


### PR DESCRIPTION
I added an option to overwrite the variables. This has been useful to me for a number of reasons, like overriding `NODE_ENV` for staging environments on the fly to test, loading multiple env files in succession, etc. In the process of adding a new test for it, I discovered that the stubs in `beforeEach` weren't setting the `TEST` env properly (they were looking at `test` instead), so the test for `does not write over keys already in process.env` was guaranteed to succeed, but not because the code was running correctly -- it was just assigning `process.env.test` rather than `process.env.TEST`. This patch also fixes that.