### PR TITLE
preload module

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -18,8 +18,8 @@ npm test
 
 ## Code Style
 
-We use [eslint](http://eslint.org) and [editorconfig](http://editorconfig.org) to maintain code style and best practices. Please make sure your PR adheres to the guides by running:
+We use [standard](https://www.npmjs.com/package/standard) and [editorconfig](http://editorconfig.org) to maintain code style and best practices. Please make sure your PR adheres to the guides by running:
 
 ```
-gulp lint
+npm run lint
 ```

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ Dotenv loads environment variables from `.env` into `ENV` (process.env).
 [![NPM version](https://img.shields.io/npm/v/dotenv.svg?style=flat-square)](https://www.npmjs.com/package/dotenv)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/feross/standard)
 
-> "Storing [configuration in the environment](http://www.12factor.net/config) 
-> is one of the tenets of a [twelve-factor app](http://www.12factor.net/). 
-> Anything that is likely to change between deployment environments–such as 
-> resource handles for databases or credentials for external services–should be 
+> "Storing [configuration in the environment](http://www.12factor.net/config)
+> is one of the tenets of a [twelve-factor app](http://www.12factor.net/).
+> Anything that is likely to change between deployment environments–such as
+> resource handles for databases or credentials for external services–should be
 > extracted from the code into environment variables.
 >
-> But it is not always practical to set environment variables on development 
-> machines or continuous integration servers where multiple projects are run. 
-> Dotenv loads variables from a `.env` file into ENV when the environment is 
+> But it is not always practical to set environment variables on development
+> machines or continuous integration servers where multiple projects are run.
+> Dotenv loads variables from a `.env` file into ENV when the environment is
 > bootstrapped."
 >
 > [Brandon Keepers' Dotenv in Ruby](https://github.com/bkeepers/dotenv)
@@ -35,7 +35,7 @@ As early as possible in your application, require and load dotenv.
 require('dotenv').load();
 ```
 
-Create a `.env` file in the root directory of your project. Add 
+Create a `.env` file in the root directory of your project. Add
 environment-specific variables on new lines in the form of `NAME=VALUE`.
 For example:
 
@@ -57,9 +57,24 @@ db.connect({
 });
 ```
 
+### Preload
+
+If you are using iojs-v1.6.0 or later, you can use the `--require` (`-r`) command line option to preload dotenv. By doing this, you do not need to require and load dotenv in your application code.
+
+
+```bash
+$ node -r dotenv/config your_script.js
+```
+
+The configuration options below are supported as command line arguments in the format `dotenv_config_<option>=value`
+
+```bash
+$ node -r dotenv/config your_script.js dotenv_config_path=/custom/path/to/your/env/vars
+```
+
 ## Config
 
-`config` will read your .env file, parse the contents, and assign it to 
+`config` will read your .env file, parse the contents, and assign it to
 `process.env` - just like `load` does. You can additionally, pass options to
 `config`.
 
@@ -71,7 +86,7 @@ Note: `config` and `load` are synonyms. You can pass options to either.
 
 Default: `false`
 
-Dotenv outputs a warning to your console if missing a `.env` file. Suppress 
+Dotenv outputs a warning to your console if missing a `.env` file. Suppress
 this warning using silent.
 
 ```js
@@ -82,7 +97,7 @@ require('dotenv').config({silent: true});
 
 Default: `.env`
 
-You can specify a custom path if your file containing environment variables is 
+You can specify a custom path if your file containing environment variables is
 named or located differently.
 
 ```js
@@ -93,7 +108,7 @@ require('dotenv').config({path: '/custom/path/to/your/env/vars'});
 
 Default: `utf8`
 
-You may specify the encoding of your file containing environment variables 
+You may specify the encoding of your file containing environment variables
 using this option.
 
 ```js
@@ -102,8 +117,8 @@ require('dotenv').config({encoding: 'base64'});
 
 ## Parse
 
-The engine which parses the contents of your file containing environment 
-variables is available to use. It accepts a String or Buffer and will return 
+The engine which parses the contents of your file containing environment
+variables is available to use. It accepts a String or Buffer and will return
 an Object with the parsed keys and values.
 
 ```js
@@ -139,9 +154,9 @@ BASIC=basic
 TEST=$BASIC
 ```
 
-Parsing that would result in `{BASIC: 'basic', TEST: 'basic'}`. You can escape 
-variables by quoting or beginning with `\` (e.g. `TEST=\$BASIC`). If the 
-variable is not found in the file, `process.env` is checked. Missing variables 
+Parsing that would result in `{BASIC: 'basic', TEST: 'basic'}`. You can escape
+variables by quoting or beginning with `\` (e.g. `TEST=\$BASIC`). If the
+variable is not found in the file, `process.env` is checked. Missing variables
 result in an empty string.
 
 ```
@@ -162,9 +177,9 @@ TEST=example node -e 'require("dotenv").config();'
 
 ### Should I commit my .env file?
 
-No. We **strongly** recommend against committing your .env file to version 
-control. It should only include environment-specific values such as database 
-passwords or API keys. Your production database should have a different 
+No. We **strongly** recommend against committing your .env file to version
+control. It should only include environment-specific values such as database
+passwords or API keys. Your production database should have a different
 password than your development database.
 
 ## Contributing
@@ -181,4 +196,3 @@ Here's just a few of many repositories using dotenv:
 * [google-oauth2-service-account](https://github.com/jacoblwe20/google-oauth2-service-account)
 * [kibble](https://github.com/motdotla/kibble)
 * [github-streaker](https://github.com/motdotla/github-streaker)
-

--- a/config.js
+++ b/config.js
@@ -1,0 +1,11 @@
+(function () {
+  var options = {}
+  process.argv.forEach(function (val, idx, arr) {
+    var matches = val.match(/^dotenv_config_(.+)=(.+)/)
+    if (matches) {
+      options[matches[1]] = matches[2]
+    }
+  })
+
+  require('./lib/main').config(options)
+})()

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
   "license": "BSD-2-Clause",
   "devDependencies": {
     "lab": "^5.3.0",
+    "semver": "^4.3.6",
     "should": "4.4.2",
     "sinon": "1.12.2",
     "standard": "^2.10.0"
   },
-  "dependencies": {
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Loads environment variables from .env file",
   "main": "lib/main.js",
   "scripts": {
-    "test": "lab test/* --coverage && standard"
+    "test": "lab test/* --coverage && standard",
+    "lint": "standard"
   },
   "repository": {
     "type": "git",

--- a/test/config.js
+++ b/test/config.js
@@ -1,0 +1,32 @@
+'use strict'
+
+require('should')
+var child_process = require('child_process')
+// var sinon = require('sinon')
+var Lab = require('lab')
+var lab = exports.lab = Lab.script()
+var describe = lab.experiment
+// var before = lab.before
+// var beforeEach = lab.beforeEach
+// var afterEach = lab.afterEach
+var it = lab.test
+var nodeBinary = process.argv[0]
+
+describe('config', function () {
+  describe('preload', function () {
+    it('loads .env', function (done) {
+      child_process.exec(
+        nodeBinary + ' -r ../config -e "console.log(process.env.BASIC)" dotenv_config_path=./test/.env',
+        function (err, stdout, stderr) {
+          if (err) {
+            return done(err)
+          }
+
+          stdout.trim().should.eql('basic')
+
+          done()
+        }
+      )
+    })
+  })
+})

--- a/test/config.js
+++ b/test/config.js
@@ -2,6 +2,7 @@
 
 require('should')
 var child_process = require('child_process')
+var semver = require('semver')
 // var sinon = require('sinon')
 var Lab = require('lab')
 var lab = exports.lab = Lab.script()
@@ -15,6 +16,11 @@ var nodeBinary = process.argv[0]
 describe('config', function () {
   describe('preload', function () {
     it('loads .env', function (done) {
+      // preloading was introduced in v1.6.0 so skip test for other environments
+      if (semver.lt(process.env.npm_config_node_version, '1.6.0')) {
+        return done()
+      }
+
       child_process.exec(
         nodeBinary + ' -r ../config -e "console.log(process.env.BASIC)" dotenv_config_path=./test/.env',
         function (err, stdout, stderr) {


### PR DESCRIPTION
With iojs 1.6.0 you can preload modules using the `-r` flag.

```shell
iojs -r babel/register index.js
```

it would be awesome to be able to use **dotenv** like this.

```shell
iojs -r dotenv/load index.js
```

would load in all env variables without boilerplate code at top of the page.