### PR TITLE
add variable interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,27 @@ TEST=example node -e 'require("dotenv").config();'
 - `process.env.TEST` would equal `example`
 - `process.env.DNE` would equal `""`
 
+#### Variable Interpolation
+
+Basic variable Interpolation is supported.
+
+```
+BASIC=basic
+TEST={$BASIC}test
+```
+
+Parsing that would result in `{BASIC: 'basic', TEST: 'basictest'}`.
+
+You can also use.
+
+```
+BASIC=basic
+TEST1={$BASIC} test
+TEST2="{$BASIC} test"
+```
+
+Parsing that would result in `{BASIC: 'basic', TEST1: 'basic test', TEST2: 'basic test'}`.
+
 ## FAQ
 
 ### Should I commit my .env file?

--- a/lib/main.js
+++ b/lib/main.js
@@ -75,6 +75,14 @@ module.exports = {
           var possibleVar = value.substring(1)
           value = obj[possibleVar] || process.env[possibleVar] || ''
         }
+
+        // is there any variable interpolation?
+        while (value.match(/\{\$(.*?)\}/) != null) {
+          var possibleVar = value.match(/\{\$(.*?)\}/)[1]
+          var possibleVal = obj[possibleVar] || process.env[possibleVar] || ''
+          value = value.replace((/\{(.*?)\}/), possibleVal)
+        }
+
         // varaible can be escaped with a \$
         if (value.substring(0, 2) === '\\$') {
           value = value.substring(1)


### PR DESCRIPTION
sometimes it could be necessary to concat a process variable with another.
this commit will use the following method to do that.
```
BASIC=basic
TEST={$BASIC}test
```
will result in `{BASIC: 'basic', TEST: 'basictest'}`.