### PR TITLE
Add cli command

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+var spawn = require('child_process').spawn
+var dotenv = require('dotenv')
+
+dotenv.load({path: process.cwd() + '/.env'})
+
+spawn(process.argv[2], process.argv.slice(3), {stdio: 'inherit'})

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "lab test/* --coverage && standard",
     "lint": "standard"
   },
+  "bin": "./cli.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/motdotla/dotenv.git"


### PR DESCRIPTION
This is a very basic cli, but could be enough for most purposes.

When installed globally, it can then be used as `dotenv <normal command>` and then the normal command will have the necessary environment variables.

Please let me know if anything needs changing. Or if this should be a seperate module.