### PR TITLE
adhere to padded-blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "semver": "^4.3.6",
     "should": "4.4.2",
     "sinon": "1.12.2",
-    "standard": "^2.10.0"
+    "standard": "^5.1.0"
   },
   "dependencies": {}
 }

--- a/test/main.js
+++ b/test/main.js
@@ -91,7 +91,6 @@ describe('dotenv', function () {
       errorStub.called.should.be.false
       done()
     })
-
   })
 
   describe('parse', function () {


### PR DESCRIPTION
We are in the process of adding back the rule `padded-blocks` into `standard`. It was temporarily disabled because of a bug in eslint which now has been fixed.

This pull request makes sure that your coding style is compliant with the new version.

Please see feross/standard#170 for more info.