### PR TITLE
use npm posttest run script for linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Loads environment variables from .env file",
   "main": "lib/main.js",
   "scripts": {
-    "test": "lab test/* --coverage && standard",
+    "test": "lab test/* --coverage",
+    "posttest": "npm run lint",
     "lint": "standard"
   },
   "repository": {


### PR DESCRIPTION
[This npm blog post this week](http://blog.npmjs.org/post/127671403050/testing-and-deploying-with-ordered-npm-run-scripts) felt like it was written for us. I like it for a few reasons:

- reinforces how to run just the linting if that's what's failing
- allows us to specify the linting behavior in one location
- makes for simpler script commands 

_I'd put my money on `standard` keeping with a simple command but if it were to grow into what `lab` offers, then it's nice to keep these separate for the last two points_