### PR TITLE
add returns option to return as object

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="https://raw.githubusercontent.com/motdotla/dotenv/master/dotenv.png" alt="dotenv" align="right" />
 
-Dotenv loads environment variables from `.env` into `ENV` (process.env).
+Dotenv loads environment variables from `.env` into `ENV` (process.env for default).
 
 [![BuildStatus](https://img.shields.io/travis/motdotla/dotenv/master.svg?style=flat-square)](https://travis-ci.org/motdotla/dotenv)
 [![NPM version](https://img.shields.io/npm/v/dotenv.svg?style=flat-square)](https://www.npmjs.com/package/dotenv)
@@ -114,6 +114,13 @@ using this option.
 ```js
 require('dotenv').config({encoding: 'base64'});
 ```
+
+#### Returns
+
+Default: `Boolean`
+
+You may specify the returns using `Boolean` which extends environment to
+`process.env` or use `Object` which returns you object with environment values.
 
 ## Parse
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -5,13 +5,14 @@ var fs = require('fs')
 module.exports = {
   /*
    * Main entry point into dotenv. Allows configuration before loading .env and .env.$NODE_ENV
-   * @param {Object} options - valid options: path ('.env'), encoding ('utf8')
-   * @returns {Boolean}
+   * @param {Object} options - valid options: path ('.env'), encoding ('utf8'), returns ('Boolean')
+   * @returns {Boolean|Object}
   */
   config: function (options) {
     var path = '.env'
     var encoding = 'utf8'
     var silent = false
+    var returns = 'Boolean'
 
     if (options) {
       if (options.silent) {
@@ -23,11 +24,17 @@ module.exports = {
       if (options.encoding) {
         encoding = options.encoding
       }
+      if (options.returns === 'Object') {
+        returns = 'Object'
+      }
     }
 
     try {
       // specifying an encoding returns a string instead of a buffer
       var parsedObj = this.parse(fs.readFileSync(path, { encoding: encoding }))
+      if (returns === 'Object') {
+        return parsedObj
+      }
 
       Object.keys(parsedObj).forEach(function (key) {
         process.env[key] = process.env[key] || parsedObj[key]

--- a/test/main.js
+++ b/test/main.js
@@ -49,6 +49,13 @@ describe('dotenv', function () {
       done()
     })
 
+    it('takes option for returns', function (done) {
+      var obj = dotenv.config({returns: 'Object'})
+
+      obj.test.should.eql('val')
+      done()
+    })
+
     it('reads path with encoding, parsing output to process.env', function (done) {
       dotenv.config()
 


### PR DESCRIPTION
This commit is for users who wants `.env` environments as Object, not extends `process.env`