### PR TITLE
add 0.10 for LTS, drop iojs in favor of v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 
 node_js:
+  - 0.10
   - 0.12
-  - iojs
   - 4

--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
   "author": "scottmotte",
   "license": "BSD-2-Clause",
   "devDependencies": {
-    "babel": "^5.8.23",
-    "lab": "^5.17.0",
-    "semver": "^5.0.3",
+    "babel": "5.8.23",
+    "lab": "5.17.0",
+    "semver": "5.0.3",
     "should": "7.1.0",
     "sinon": "1.16.1",
-    "standard": "^5.3.0"
+    "standard": "5.0.0"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
some pretty big changes came to standard [between v5.0.0 and v5.0.1](https://github.com/feross/standard/compare/v5.0.0...v5.0.1) which makes installing it error using node v0.10. See [this travis job](https://travis-ci.org/motdotla/dotenv/jobs/80773606) for details. My local errors similarly:

```
~/Sites/dotenv on sm-dependencies
$ npm i standard@5.0.1
npm ERR! not a package /var/folders/v6/249xbd5x3rx3_q889fyf2bth0000gn/T/npm-13628-3QfkgRWs/github.com/eslint/eslint.git
npm ERR! Error: ENOENT, open '/var/folders/v6/249xbd5x3rx3_q889fyf2bth0000gn/T/npm-13628-3QfkgRWs/github.com/eslint/eslint.git-unpack/package.json'
npm ERR! If you need help, you may report this *entire* log,
npm ERR! including the npm and node versions, at:
npm ERR!     <http://github.com/npm/npm/issues>

npm ERR! System Darwin 14.5.0
npm ERR! command "/Users/max/.nvm/v0.10.40/bin/node" "/Users/max/.nvm/v0.10.40/bin/npm" "i" "standard@5.0.1"
npm ERR! cwd /Users/max/Sites/dotenv
npm ERR! node -v v0.10.40
npm ERR! npm -v 1.4.28
npm ERR! path /var/folders/v6/249xbd5x3rx3_q889fyf2bth0000gn/T/npm-13628-3QfkgRWs/github.com/eslint/eslint.git-unpack/package.json
npm ERR! code ENOENT
npm ERR! errno 34
npm ERR! not ok code 0
```

Going to open an issue to ask for guidance