### PR TITLE
Add option to overwrite existing process.env variables with .env values

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,17 @@ using this option.
 require('dotenv').config({encoding: 'base64'});
 ```
 
+#### Force
+
+Default: `false`
+
+By default, dotenv **will not** write over existing environment variables in `process.env`.
+You can change this behavior by setting this option to `true`.
+
+```js
+require('dotenv').config({force: true});
+```
+
 ## Parse
 
 The engine which parses the contents of your file containing environment
@@ -151,7 +162,7 @@ No. We **strongly** recommend against having a "main" `.env` file and an "enviro
 
 ### What happens to environment variables that were already set?
 
-We will never modify any environment variables that have already been set. In particular, if there is a variable in your `.env` file which collides with one that already exists in your environment, then that variable will be skipped. This behavior allows you to override all `.env` configurations with a machine-specific environment, although it is not recommended.
+By default, this module will never modify any environment variables that have already been set. In particular, if there is a variable in your `.env` file which collides with one that already exists in your environment, then that variable will be skipped unless using the [force option](#force).
 
 ### Can I customize/write plugins for dotenv?
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -12,6 +12,7 @@ module.exports = {
     var path = '.env'
     var encoding = 'utf8'
     var silent = false
+    var force = false
 
     if (options) {
       if (options.silent) {
@@ -23,6 +24,9 @@ module.exports = {
       if (options.encoding) {
         encoding = options.encoding
       }
+      if (options.force) {
+        force = options.force
+      }
     }
 
     try {
@@ -30,7 +34,7 @@ module.exports = {
       var parsedObj = this.parse(fs.readFileSync(path, { encoding: encoding }))
 
       Object.keys(parsedObj).forEach(function (key) {
-        process.env[key] = process.env[key] || parsedObj[key]
+        process.env[key] = force === true ? parsedObj[key] : process.env[key] || parsedObj[key]
       })
 
       return parsedObj

--- a/test/main.js
+++ b/test/main.js
@@ -65,12 +65,30 @@ describe('dotenv', function () {
       done()
     })
 
-    it('does not write over keys already in process.env', function (done) {
+    it('does not write over keys already in process.env by default', function (done) {
       process.env.TEST = 'test'
       // 'val' returned as value in `beforeEach`. should keep this 'test'
       dotenv.config()
 
       process.env.TEST.should.eql('test')
+      done()
+    })
+
+    it('writes over keys already in process.env when force option is enabled', function (done) {
+      process.env.test = 'test'
+      // 'val' returned as value in `beforeEach`
+      dotenv.config({ force: true })
+
+      process.env.test.should.eql('val')
+      done()
+    })
+
+    it('does not write over keys already in process.env when force option is disabled', function (done) {
+      process.env.test = 'test'
+      // 'val' returned as value in `beforeEach`
+      dotenv.config({ force: false })
+
+      process.env.test.should.eql('test')
       done()
     })
 


### PR DESCRIPTION
**This pull request adds a `force` option that (when set) will write over existing environment variables with values from the application's `.env` file.** It is disabled by default so that it is non-breaking.

Also, this pull request fixes a false-positive test due to case-sensitive `process.env` variables.

---

Here is some background on the proposed option. I'm open to discussing alternatives.

Because this module only applies the `.env` values to the application scope (i.e. `process.env`), overwriting existing values will not affect other programs outside of the application that rely on machine-specific variables (i.e. non-destructive to the machine's environment).

When enabled, it provides more consistent and predictable behavior to the application's environment – in other words the values you see in the `.env` file are the values your application will get (think _WYSIWYG_).

_Related to #102, #107, #115_