### PR TITLE
Fix false-positive test due to case-sensitive process.env variables

### DIFF
--- a/test/main.js
+++ b/test/main.js
@@ -66,11 +66,11 @@ describe('dotenv', function () {
     })
 
     it('does not write over keys already in process.env', function (done) {
-      process.env.TEST = 'test'
+      process.env.test = 'test'
       // 'val' returned as value in `beforeEach`. should keep this 'test'
       dotenv.config()
 
-      process.env.TEST.should.eql('test')
+      process.env.test.should.eql('test')
       done()
     })
 


### PR DESCRIPTION
_Moved from #123_

This test was returning a false positive because the `readFileSyncStub` loads `test=val` (lowercase) and the test is checking for `process.env.TEST` (uppercase), thus never colliding with an existing env variable.