### PR TITLE
Add override option

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ using this option.
 require('dotenv').config({encoding: 'base64'});
 ```
 
+#### Override
+
+Default: `false`
+
+You may specify that system environemnt variables should be overridden by those in a `.env` file.
+
+```js
+require('dotenv').config({override: true});
+```
+
 ## Parse
 
 The engine which parses the contents of your file containing environment
@@ -152,6 +162,8 @@ No. We **strongly** recommend against having a "main" `.env` file and an "enviro
 ### What happens to environment variables that were already set?
 
 We will never modify any environment variables that have already been set. In particular, if there is a variable in your `.env` file which collides with one that already exists in your environment, then that variable will be skipped. This behavior allows you to override all `.env` configurations with a machine-specific environment, although it is not recommended.
+
+**Note**: This behavior can be overriden by setting the `override` config option to `true`.
 
 ### Can I customize/write plugins for dotenv?
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -12,6 +12,7 @@ module.exports = {
     var path = '.env'
     var encoding = 'utf8'
     var silent = false
+    var override = false
 
     if (options) {
       if (options.silent) {
@@ -23,6 +24,9 @@ module.exports = {
       if (options.encoding) {
         encoding = options.encoding
       }
+      if (options.override) {
+        override = options.override
+      }
     }
 
     try {
@@ -30,7 +34,7 @@ module.exports = {
       var parsedObj = this.parse(fs.readFileSync(path, { encoding: encoding }))
 
       Object.keys(parsedObj).forEach(function (key) {
-        process.env[key] = process.env[key] || parsedObj[key]
+        process.env[key] = override ? parsedObj[key] : process.env[key] || parsedObj[key]
       })
 
       return parsedObj

--- a/test/main.js
+++ b/test/main.js
@@ -28,8 +28,8 @@ describe('dotenv', function () {
     var readFileSyncStub, parseStub
 
     beforeEach(function (done) {
-      readFileSyncStub = s.stub(fs, 'readFileSync').returns('test=val')
-      parseStub = s.stub(dotenv, 'parse').returns({test: 'val'})
+      readFileSyncStub = s.stub(fs, 'readFileSync').returns('TEST=val')
+      parseStub = s.stub(dotenv, 'parse').returns({TEST: 'val'})
       done()
     })
 

--- a/test/main.js
+++ b/test/main.js
@@ -74,6 +74,15 @@ describe('dotenv', function () {
       done()
     })
 
+    it('writes over keys already in process.env if override is set to true', function (done) {
+      process.env.TEST = 'test'
+      // 'val' returned as value in `beforeEach`.
+      dotenv.config({override: true})
+
+      process.env.TEST.should.eql('val')
+      done()
+    })
+
     it('catches any errors thrown from reading file or parsing', function (done) {
       var errorStub = s.stub(console, 'error')
       readFileSyncStub.throws()


### PR DESCRIPTION
Been burned a few times by having a system environment variable and forgetting about or not knowing that dotenv would override it. Most people on my team set a global `TWILIO_AUTH_TOKEN` in their shell config which I'm sure is common with other developers.

This adds a backwards compatible feature to force environment variables in a `.env` file to override the system ones.