### PR TITLE
added the override option in config function.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -12,6 +12,7 @@ module.exports = {
     var path = '.env'
     var encoding = 'utf8'
     var silent = false
+    var override = false
 
     if (options) {
       if (options.silent) {
@@ -23,6 +24,9 @@ module.exports = {
       if (options.encoding) {
         encoding = options.encoding
       }
+      if (options.override) {
+        override = options.override
+      }
     }
 
     try {
@@ -30,7 +34,11 @@ module.exports = {
       var parsedObj = this.parse(fs.readFileSync(path, { encoding: encoding }))
 
       Object.keys(parsedObj).forEach(function (key) {
-        process.env[key] = process.env[key] || parsedObj[key]
+        if (override) {
+          process.env[key] = parsedObj[key] || process.env[key]
+        } else {
+          process.env[key] = process.env[key] || parsedObj[key]
+        }
       })
 
       return parsedObj

--- a/test/main.js
+++ b/test/main.js
@@ -91,6 +91,22 @@ describe('dotenv', function () {
       errorStub.called.should.be.false
       done()
     })
+
+    it('does not overwrite keys in process env if option override is falsy', function (done) {
+      var testOverride = false
+      process.env.test = 'bar'
+      dotenv.config({override: testOverride})
+      process.env.test.should.eql('bar')
+      done()
+    })
+
+    it('overwrites keys in process env if option override is truthy', function (done) {
+      var testOverride = true
+      process.env.test = 'bar'
+      dotenv.config({override: testOverride})
+      process.env.test.should.eql('val')
+      done()
+    })
   })
 
   describe('parse', function () {


### PR DESCRIPTION
the override option allows the keys stated in .env to override the
keys that is present on the environment.

my case is i have several aws users with different permissions. i need the values in the dot env file to have higher precedence over those in the environment