### PR TITLE
Add link to envalid in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,3 +205,4 @@ Here's some projects that expand on dotenv. Check them out.
 
 * [require-environment-variables](https://github.com/bjoshuanoah/require-environment-variables)
 * [dotenv-safe](https://github.com/rolodato/dotenv-safe)
+* [envalid](https://github.com/af/envalid)


### PR DESCRIPTION
Hi,
I recently added dotenv support to [envalid](https://github.com/af/envalid), my library for env var validation, and thought it could be added to the readme. thanks for dotenv, it's really handy!