### PR TITLE
Try to locate .env in parents

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -5,7 +5,7 @@ var fs = require('fs')
 module.exports = {
   /*
    * Main entry point into dotenv. Allows configuration before loading .env
-   * @param {Object} options - valid options: path ('.env'), encoding ('utf8')
+   * @param {Object} options - valid options: path ('.env'), encoding ('utf8') findInParents (false)
    * @returns {Boolean}
   */
   config: function (options) {
@@ -23,6 +23,10 @@ module.exports = {
       if (options.encoding) {
         encoding = options.encoding
       }
+    }
+
+    if (!options || options && !options.path){
+      path = _findFileInParents(path, encoding, silent);
     }
 
     try {
@@ -77,6 +81,24 @@ module.exports = {
     return obj
   }
 
+}
+
+function _findFileInParents(path, encoding, silent) {
+  for (var i = 0; i < 100; i++) {
+    try{
+      fs.readFileSync(path, { encoding: encoding })
+      return path
+    }
+    catch (e){
+      path = '../' + path
+    }
+  }
+
+  if (!silent) {
+    console.error("No .env found.");
+  }
+
+  return false;
 }
 
 module.exports.load = module.exports.config


### PR DESCRIPTION
If .env is not found in current folder and no `options.path` is specified then try to locate parents.

Would you accept this feature? I can make optional. I will refactor the code according to your guidelines and cover the lines with tests if we will agree on adding this feature. Let me know.