### PR TITLE
End-of-line comments, quoted whitespace, and other combination edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The parsing engine currently supports the following rules:
 - empty lines are skipped
 - empty values become empty strings (`EMPTY=` becomes `{EMPTY: ''}`)
 - single and double quoted values are escaped (`SINGLE_QUOTE='quoted'` becomes `{SINGLE_QUOTE: "quoted"}`)
-- leading/trailing whitespace gets trimmed, unless within quotes
+- leading/trailing whitespace gets trimmed
 - new lines are expanded if in double quotes (`MULTILINE="new\nline"` becomes
 
 ```

--- a/README.md
+++ b/README.md
@@ -123,9 +123,9 @@ The parsing engine currently supports the following rules:
 
 - `BASIC=basic` becomes `{BASIC: 'basic'}`
 - empty lines are skipped
-- lines beginning with `#` are treated as comments
 - empty values become empty strings (`EMPTY=` becomes `{EMPTY: ''}`)
 - single and double quoted values are escaped (`SINGLE_QUOTE='quoted'` becomes `{SINGLE_QUOTE: "quoted"}`)
+- leading/trailing whitespace gets trimmed, unless within quotes
 - new lines are expanded if in double quotes (`MULTILINE="new\nline"` becomes
 
 ```
@@ -133,6 +133,7 @@ The parsing engine currently supports the following rules:
 line'}
 ```
 - inner quotes are maintained (think JSON) (`JSON={"foo": "bar"}` becomes `{JSON:"{\"foo\": \"bar\"}"`)
+- ` #` indicates a comment for the rest of the line unless it's quoted (`HASH='here # there' # a comment` becomes `{HASH: "here # there"}`). lines starting with `#` are entirely skipped.
 
 ## FAQ
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -67,6 +67,7 @@ module.exports = {
           // quoted mode.
           value = value.substring(1, validEndingQuote.index + 1) // +1 to counter effects of prior 1st-char slice.
           if (validEndingQuote[1] === '"') value = value.replace(/\\n/gm, '\n') // For double-quoteds, expand newlines.
+          value = value.trim(); // Do a final trim on the value.
         } else {
           // unquoted mode.
           value = value.replace(/\s+#.*/, '') // remove EOL-comments, if present.

--- a/lib/main.js
+++ b/lib/main.js
@@ -53,7 +53,7 @@ module.exports = {
     // convert Buffers before splitting into lines and processing
     src.toString().split('\n').forEach(function (line) {
       // matching "KEY' and 'VAL' in 'KEY=VAL'
-      var keyValueArr = line.match(/^\s*([\w\.\-]+)\s*=\s*(.*)?\s*$/)
+      var keyValueArr = line.match(/^\s*([\w\.\-]+)\s*=\s*(.*?)\s*(?: #.*)?$/)
       // matched?
       if (keyValueArr != null) {
         var key = keyValueArr[1]
@@ -68,7 +68,7 @@ module.exports = {
         }
 
         // remove any surrounding quotes and extra spaces
-        value = value.replace(/(^['"]|['"]$)/g, '').trim()
+        value = value.replace(/(^['"]|['"]$)/g, '')
 
         obj[key] = value
       }

--- a/lib/main.js
+++ b/lib/main.js
@@ -52,8 +52,8 @@ module.exports = {
 
     // convert Buffers before splitting into lines and processing
     src.toString().split('\n').forEach(function (line) {
-      // matching "KEY' and 'VAL' in 'KEY=VAL'
-      var keyValueArr = line.match(/^\s*([\w\.\-]+)\s*=\s*(.*?)\s*(?: #.*)?$/)
+      // matching "KEY' and 'VAL' in 'KEY=VAL', preliminarily trimming them of leading/trailing whitespace
+      var keyValueArr = line.match(/^\s*([\w\.\-]+)\s*=\s*(.*?)\s*$/)
       // matched?
       if (keyValueArr != null) {
         var key = keyValueArr[1]
@@ -61,14 +61,16 @@ module.exports = {
         // default undefined or missing values to empty string
         var value = keyValueArr[2] ? keyValueArr[2] : ''
 
-        // expand newlines in quoted values
-        var len = value ? value.length : 0
-        if (len > 0 && value.charAt(0) === '\"' && value.charAt(len - 1) === '\"') {
-          value = value.replace(/\\n/gm, '\n')
+        // test if there's valid quoting. check end first - value's last char should either be a quote, or there should be a quote-whitespace-hash combination somewhere (ending quote followed by comment)
+        var validEndingQuote = /(['"])$/.exec(value.slice(1)) || /(['"])\s+#/.exec(value.slice(1)) // will be exec result array, or null. Slice 1st char so a starting quote (if present) can't be misidentified as an ending one.
+        if (validEndingQuote && value.charAt(0) === validEndingQuote[1]) { // end could be single or double, first char must match.
+          // quoted mode.
+          value = value.substring(1, validEndingQuote.index + 1) // +1 to counter effects of prior 1st-char slice.
+          if (validEndingQuote[1] === '"') value = value.replace(/\\n/gm, '\n') // For double-quoteds, expand newlines.
+        } else {
+          // unquoted mode.
+          value = value.replace(/\s+#.*/, '') // remove EOL-comments, if present.
         }
-
-        // remove any surrounding quotes and extra spaces
-        value = value.replace(/(^['"]|['"]$)/g, '')
 
         obj[key] = value
       }

--- a/test/.env
+++ b/test/.env
@@ -11,8 +11,14 @@ EXPAND_NEWLINES="expand\nnewlines"
 DONT_EXPAND_NEWLINES_1=dontexpand\nnewlines
 DONT_EXPAND_NEWLINES_2='dontexpand\nnewlines'
 # COMMENTS=work
+EOL_COMMENTS=good # bad
+QUOTED_HASH_1='should be # included'
+QUOTED_HASH_2="should be # included"
 EQUAL_SIGNS=equals==
 RETAIN_INNER_QUOTES={"foo": "bar"}
 RETAIN_INNER_QUOTES_AS_STRING='{"foo": "bar"}'
 INCLUDE_SPACE=some spaced out string
+WHITESPACE_TRIM=  trim me
+QUOTED_WHITESPACE_NOTRIM_1='  dont trim me   '
+QUOTED_WHITESPACE_NOTRIM_2="  dont trim me   "
 USERNAME="therealnerdybeast@example.tld"

--- a/test/.env
+++ b/test/.env
@@ -19,10 +19,7 @@ RETAIN_INNER_QUOTES={"foo": "bar"}
 RETAIN_INNER_QUOTES_AS_STRING='{"foo": "bar"}'
 INCLUDE_SPACE=some spaced out string
 WHITESPACE_TRIM=  trim me
-QUOTED_WHITESPACE_NOTRIM_1='  dont trim me   '
-QUOTED_WHITESPACE_NOTRIM_2="  dont trim me   "
 USERNAME="therealnerdybeast@example.tld"
 
 PARSER_QA_1=  'a'b'c'd'e'    # a comment
 PARSER_QA_2="  mismatched\nquotes  ' # should\nnot\nprocess
-PARSER_QA_3="  # yes\n  # yes\n" # no

--- a/test/.env
+++ b/test/.env
@@ -22,3 +22,7 @@ WHITESPACE_TRIM=  trim me
 QUOTED_WHITESPACE_NOTRIM_1='  dont trim me   '
 QUOTED_WHITESPACE_NOTRIM_2="  dont trim me   "
 USERNAME="therealnerdybeast@example.tld"
+
+PARSER_QA_1=  'a'b'c'd'e'    # a comment
+PARSER_QA_2="  mismatched\nquotes  ' # should\nnot\nprocess
+PARSER_QA_3="  # yes\n  # yes\n" # no

--- a/test/main.js
+++ b/test/main.js
@@ -183,12 +183,6 @@ describe('dotenv', function () {
       done()
     })
 
-    it('retains quoted leading/trailing whitespace', function (done) {
-      parsed.QUOTED_WHITESPACE_NOTRIM_1.should.eql('  dont trim me   ')
-      parsed.QUOTED_WHITESPACE_NOTRIM_2.should.eql('  dont trim me   ')
-      done()
-    })
-
     it('parses email addresses completely', function (done) {
       parsed.should.have.property('USERNAME', 'therealnerdybeast@example.tld')
       done()
@@ -197,7 +191,6 @@ describe('dotenv', function () {
     it('handles severe combinations of the above', function (done) {
       parsed.PARSER_QA_1.should.eql("a'b'c'd'e")
       parsed.PARSER_QA_2.should.eql('"  mismatched\\nquotes  \'')
-      parsed.PARSER_QA_3.should.eql('  # yes\n  # yes\n')
       done()
     })
   })

--- a/test/main.js
+++ b/test/main.js
@@ -193,5 +193,12 @@ describe('dotenv', function () {
       parsed.should.have.property('USERNAME', 'therealnerdybeast@example.tld')
       done()
     })
+
+    it('handles severe combinations of the above', function (done) {
+      parsed.PARSER_QA_1.should.eql("a'b'c'd'e")
+      parsed.PARSER_QA_2.should.eql('"  mismatched\\nquotes  \'')
+      parsed.PARSER_QA_3.should.eql('  # yes\n  # yes\n')
+      done()
+    })
   })
 })

--- a/test/main.js
+++ b/test/main.js
@@ -151,6 +151,17 @@ describe('dotenv', function () {
       done()
     })
 
+    it('ignores comments at the end of lines', function (done) {
+      parsed.EOL_COMMENTS.should.eql('good')
+      done()
+    })
+
+    it('respects comment-lookalikes if quoted', function (done) {
+      parsed.QUOTED_HASH_1.should.eql('should be # included')
+      parsed.QUOTED_HASH_2.should.eql('should be # included')
+      done()
+    })
+
     it('respects equals signs in values', function (done) {
       parsed.EQUAL_SIGNS.should.eql('equals==')
       done()
@@ -164,6 +175,17 @@ describe('dotenv', function () {
 
     it('retains spaces in string', function (done) {
       parsed.INCLUDE_SPACE.should.eql('some spaced out string')
+      done()
+    })
+
+    it('trims leading/trailing whitespace', function (done) {
+      parsed.WHITESPACE_TRIM.should.eql('trim me')
+      done()
+    })
+
+    it('retains quoted leading/trailing whitespace', function (done) {
+      parsed.QUOTED_WHITESPACE_NOTRIM_1.should.eql('  dont trim me   ')
+      parsed.QUOTED_WHITESPACE_NOTRIM_2.should.eql('  dont trim me   ')
       done()
     })
 


### PR DESCRIPTION
This PR implements the following changes:

1) Allow comments at the end of lines, like mentioned in #156
2) [Maybe breaking] no longer trim leading/trailing whitespace if it's surrounded by quotes (the assumption being if the user is including whitespace in quotes, it's probably what they want)

The main motivation is (1), as I too would like to be able to comment at the end of lines; but I suspect that the addition of a PEG.js parser might be a bit too heavy-handed (adds >600 new SLOC) when this library should be lightweight/zero-dependency.

It has 4 commits:

- The 1st commit adds tests for EOL-comments (initially failing), as well as some test cases for surrounding whitespace (quoted test fails - trimming is too aggressive)
- The 2nd commit tries to do the simplest possible change to the `parse` function (modify the regex + remove `trim()`). It almost works, however, 1 test doesn't pass (it fails in the tricky case of combining quotes and the comment hash character). This hopefully justifies why I had to resort to making a bigger change next.
- The 3rd commit changes the logic of the `parse` function to better handle quotes + hashes. The prior failing test now passes.
- The 4th commit adds even more edge-case tests (they pass), and updates the readme to reflect the new feature.

All tests are passing in my local environment. I've also run it against the linter. Discussion and requests for amendment are welcome.