### PR TITLE
Add support for throwing if failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+
+- Return Object with parsed content or error instead of false ([#165](https://github.com/motdotla/dotenv/pull/165)).
+
+
+### Removed
+
+- `verbose` option removed in favor of returning result.
+
 
 ## [3.0.0]
 ### Added

--- a/README.md
+++ b/README.md
@@ -65,21 +65,12 @@ $ node -r dotenv/config your_script.js dotenv_config_path=/custom/path/to/your/e
 
 _Alias: `load`_
 
-`config` will read your .env file, parse the contents, and assign it to
-[`process.env`](https://nodejs.org/docs/latest/api/process.html#process_process_env). You can additionally, pass options to
-`config`.
+`config` will read your .env file, parse the contents, assign it to
+[`process.env`](https://nodejs.org/docs/latest/api/process.html#process_process_env),
+and return an Object with a _parsed_ key containing the loaded content or an _error_ key if it failed.  
+You can additionally, pass options to `config`.
 
 ### Options
-
-#### Verbose
-
-Default: `false`
-
-All errors are suppressed by default. Set this to `true` for more logging.
-
-```js
-require('dotenv').config({verbose: true})
-```
 
 #### Path
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -45,12 +45,8 @@ function parse (src) {
 function config (options) {
   var path = '.env'
   var encoding = 'utf8'
-  var verbose = false
 
   if (options) {
-    if (options.verbose) {
-      verbose = options.verbose
-    }
     if (options.path) {
       path = options.path
     }
@@ -67,12 +63,9 @@ function config (options) {
       process.env[key] = process.env[key] || parsedObj[key]
     })
 
-    return parsedObj
+    return { parsed: parsedObj }
   } catch (e) {
-    if (verbose) {
-      console.error('dotenv failed to parse and/or populate:' + e.message)
-    }
-    return false
+    return { error: e }
   }
 }
 

--- a/test/main.js
+++ b/test/main.js
@@ -74,21 +74,20 @@ describe('dotenv', function () {
       done()
     })
 
-    it('catches any errors thrown from reading file or parsing', function (done) {
-      var errorStub = s.stub(console, 'error')
-      readFileSyncStub.throws()
+    it('returns parsed object', function (done) {
+      var env = dotenv.config()
 
-      dotenv.config().should.eql(false)
-      errorStub.called.should.be.false // because verbose is off
+      env.should.not.have.property('error')
+      env.parsed.should.eql({ test: 'val' })
       done()
     })
 
-    it('takes option for exposing errors', function (done) {
-      var errorStub = s.stub(console, 'error')
+    it('returns any errors thrown from reading file or parsing', function (done) {
       readFileSyncStub.throws()
 
-      dotenv.config({verbose: true}).should.eql(false)
-      errorStub.callCount.should.eql(1)
+      var env = dotenv.config()
+      env.should.have.property('error')
+      env.error.should.be.instanceOf(Error)
       done()
     })
   })


### PR DESCRIPTION
If `verbose: 'throw'` is passed in options, an `Error` is thrown instead of `console.error`ing to the stdout