### PR TITLE
Add option 'proc': when set to false it will not modify process.env.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -45,6 +45,7 @@ function parse (src) {
 function config (options) {
   var path = '.env'
   var encoding = 'utf8'
+  var proc = true
 
   if (options) {
     if (options.path) {
@@ -53,15 +54,20 @@ function config (options) {
     if (options.encoding) {
       encoding = options.encoding
     }
+    if (options.proc) {
+      proc = options.proc
+    }
   }
 
   try {
     // specifying an encoding returns a string instead of a buffer
     var parsedObj = parse(fs.readFileSync(path, { encoding: encoding }))
 
-    Object.keys(parsedObj).forEach(function (key) {
-      process.env[key] = process.env[key] || parsedObj[key]
-    })
+    if (proc) {
+      Object.keys(parsedObj).forEach(function (key) {
+        process.env[key] = process.env[key] || parsedObj[key]
+      })
+    }
 
     return { parsed: parsedObj }
   } catch (e) {


### PR DESCRIPTION
Sometimes you want to only read in environment variables without modifying process.env.  This is useful when reading a .env file prior to spawning a new process, for example.  The 'proc' option defaults to true.  If set to false, it will not modify process.env, just return the parsed object.