### PR TITLE
Parse lines beginning with "export"

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -13,13 +13,13 @@ function parse (src) {
   // convert Buffers before splitting into lines and processing
   src.toString().split('\n').forEach(function (line) {
     // matching "KEY' and 'VAL' in 'KEY=VAL'
-    var keyValueArr = line.match(/^\s*([\w\.\-]+)\s*=\s*(.*)?\s*$/)
+    var keyValueArr = line.match(/^(export\s)?\s*([\w\.\-]+)\s*=\s*(.*)?\s*$/)
     // matched?
     if (keyValueArr != null) {
-      var key = keyValueArr[1]
+      var key = keyValueArr[2]
 
       // default undefined or missing values to empty string
-      var value = keyValueArr[2] ? keyValueArr[2] : ''
+      var value = keyValueArr[3] ? keyValueArr[3] : ''
 
       // expand newlines in quoted values
       var len = value ? value.length : 0

--- a/test/.env
+++ b/test/.env
@@ -16,3 +16,4 @@ RETAIN_INNER_QUOTES={"foo": "bar"}
 RETAIN_INNER_QUOTES_AS_STRING='{"foo": "bar"}'
 INCLUDE_SPACE=some spaced out string
 USERNAME="therealnerdybeast@example.tld"
+export EXPORTED=true

--- a/test/main.js
+++ b/test/main.js
@@ -150,6 +150,11 @@ describe('dotenv', function () {
       done()
     })
 
+    it('includes export lines', function (done) {
+      parsed.should.have.property('EXPORTED')
+      done()
+    })
+
     it('respects equals signs in values', function (done) {
       parsed.EQUAL_SIGNS.should.eql('equals==')
       done()


### PR DESCRIPTION
We commonly attempt to reuse our `.env` files by including `export ` at the beginning of each line. This allows our `.env` files to also be sourced and loaded into our environment if necessary.  Similar dotenv packages seem to allow this functionality (ie. https://github.com/bkeepers/dotenv#usage).

This pull request maintains all existing functionality.  It adds one additional change.  A line formatted as

```
export EXPORTED=true
```

will be parsed with key `EXPORTED` and value `true`.