### PR TITLE
Return inserted, in addition to parsed

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -58,12 +58,16 @@ function config (options) {
   try {
     // specifying an encoding returns a string instead of a buffer
     var parsedObj = parse(fs.readFileSync(path, { encoding: encoding }))
+    var insertedObj = {}
 
     Object.keys(parsedObj).forEach(function (key) {
-      process.env[key] = process.env[key] || parsedObj[key]
+      var value = process.env[key] || parsedObj[key]
+
+      insertedObj[key] = value
+      process.env[key] = value
     })
 
-    return { parsed: parsedObj }
+    return { parsed: parsedObj, inserted: insertedObj }
   } catch (e) {
     return { error: e }
   }

--- a/test/main.js
+++ b/test/main.js
@@ -30,6 +30,8 @@ describe('dotenv', function () {
     beforeEach(function (done) {
       readFileSyncStub = s.stub(fs, 'readFileSync').returns('test=val')
       parseStub = s.stub(dotenv, 'parse').returns({test: 'val'})
+      delete process.env.test // clean up
+
       done()
     })
 
@@ -79,6 +81,24 @@ describe('dotenv', function () {
 
       env.should.not.have.property('error')
       env.parsed.should.eql({ test: 'val' })
+      done()
+    })
+
+    it('returns inserted object', function (done) {
+      var env = dotenv.config()
+
+      env.should.not.have.property('error')
+      env.inserted.should.eql({ test: 'val' })
+      done()
+    })
+
+    it('returns inserted values and parsed values (which can be different if already preset)', function (done) {
+      process.env.test = 'test'
+
+      var env = dotenv.config()
+
+      env.parsed.should.eql({ test: 'val' })
+      env.inserted.should.eql({ test: 'test' })
       done()
     })
 


### PR DESCRIPTION
@jcblw and @maxbeatty I'd like to get your guys' thoughts on this scenario:

1) An environment variable, `SOME_ENV`, is preset on the machine
2) `SOME_ENV` is also set in the .env file
2) dotenv runs and does not override the preset `SOME_ENV`, correctly.
3) the return object returns:

```
{ 
  parsed: {
    NODE_ENV: 'value-from-the-env-file'
  }
}
```

In this scenario the value returned is not representative of what is set in memory. 

This PR is proposing to additionally return an `inserted` object, but what do you guys think is the right move here.

I came across this when patching up dotenv-expand. Any others building libs on top of dotenv would come across the same current bug and have to write their own patch. https://github.com/motdotla/dotenv-expand/pull/6