### PR TITLE
parse `export KEY=VAL` so `.env` can be shared with shell scripts

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -13,7 +13,9 @@ function parse (src) {
   // convert Buffers before splitting into lines and processing
   src.toString().split('\n').forEach(function (line) {
     // matching "KEY' and 'VAL' in 'KEY=VAL'
-    var keyValueArr = line.match(/^\s*([\w\.\-]+)\s*=\s*(.*)?\s*$/)
+    var keyValueArr = line.
+      .replace(/^export ?/, '')
+      .match(/^\s*([\w\.\-]+)\s*=\s*(.*)?\s*$/)
     // matched?
     if (keyValueArr != null) {
       var key = keyValueArr[1]

--- a/test/.env
+++ b/test/.env
@@ -16,3 +16,4 @@ RETAIN_INNER_QUOTES={"foo": "bar"}
 RETAIN_INNER_QUOTES_AS_STRING='{"foo": "bar"}'
 INCLUDE_SPACE=some spaced out string
 USERNAME="therealnerdybeast@example.tld"
+export EXPORTED="exported-value"

--- a/test/main.js
+++ b/test/main.js
@@ -170,5 +170,10 @@ describe('dotenv', function () {
       parsed.should.have.property('USERNAME', 'therealnerdybeast@example.tld')
       done()
     })
+
+    it('parses `export KEY=VAL` syntax', function (done) {
+      parsed.should.have.property('EXPORTED', 'exported-value')
+      done()
+    })
   })
 })


### PR DESCRIPTION
We have a `.env` file that uses the following syntax:

```sh
export LOCAL_KEY="local-value"
```

This adds support for the parse function to handle preceding `export ` keywords in each line.