### PR TITLE
Do not override set vars with falsy values

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -60,7 +60,9 @@ function config (options) {
     var parsedObj = parse(fs.readFileSync(path, { encoding: encoding }))
 
     Object.keys(parsedObj).forEach(function (key) {
-      process.env[key] = process.env[key] || parsedObj[key]
+      if (!process.env.hasOwnProperty(key)) {
+        process.env[key] = parsedObj[key]
+      }
     })
 
     return { parsed: parsedObj }

--- a/test/main.js
+++ b/test/main.js
@@ -74,6 +74,15 @@ describe('dotenv', function () {
       done()
     })
 
+    it('does not write over keys already in process.env if the key has a falsy value', function (done) {
+      process.env.test = ''
+      // 'val' returned as value in `beforeEach`. should keep this ''
+      dotenv.config()
+
+      process.env.test.should.eql('')
+      done()
+    })
+
     it('returns parsed object', function (done) {
       var env = dotenv.config()
 


### PR DESCRIPTION
Currently `dotenv` would override env vars that are set but are set to a falsy value, e.g. `''`:

```
cat .env
MYVAR=value

MYVAR='' node
> process.env.MYVAR
''
> const dotenv = require('dotenv');
> dotenv.config()
{ MYVAR: 'value' }
```

This changes that behavior so that any env var that is present in `process.env` will be kept, regardless of its value:

```
cat .env
MYVAR=value

MYVAR='' node
> process.env.MYVAR
''
> const dotenv = require('dotenv');
> dotenv.config()
{ MYVAR: '' }
```

I think this would have to be considered a breaking change and would require a major version update.

Closes #202 