### PR TITLE
cut export and export arguments

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -12,6 +12,8 @@ function parse (src) {
 
   // convert Buffers before splitting into lines and processing
   src.toString().split('\n').forEach(function (line) {
+    // ignore export statements and keys
+    line = line.replace(/(export|set)\s+-\w+\s*/i, '')
     // matching "KEY' and 'VAL' in 'KEY=VAL'
     var keyValueArr = line.match(/^\s*([\w\.\-]+)\s*=\s*(.*)?\s*$/)
     // matched?


### PR DESCRIPTION
Now you can use dotenv with .env files containing export statements.
You don't need this in bash, but in fish statements isn't imported without set.