### PR TITLE
strip export statement to be compatible with other dotenv implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ The parsing engine currently supports the following rules:
 - `BASIC=basic` becomes `{BASIC: 'basic'}`
 - empty lines are skipped
 - lines beginning with `#` are treated as comments
+- export statements `export KEY=value` will be processed as it was `KEY=value`
 - empty values become empty strings (`EMPTY=` becomes `{EMPTY: ''}`)
 - single and double quoted values are escaped (`SINGLE_QUOTE='quoted'` becomes `{SINGLE_QUOTE: "quoted"}`)
 - new lines are expanded if in double quotes (`MULTILINE="new\nline"` becomes

--- a/lib/main.js
+++ b/lib/main.js
@@ -13,6 +13,11 @@ function parse (src) {
 
   // convert Buffers before splitting into lines and processing
   src.toString().split('\n').forEach(function (line) {
+    // remove export statemet "export " from beginning of line
+    if (line.substring(0, 7).toLowerCase() === 'export ') {
+      line = line.substring(7)
+    }
+
     // matching "KEY' and 'VAL' in 'KEY=VAL'
     const keyValueArr = line.match(/^\s*([\w\.\-]+)\s*=\s*(.*)?\s*$/)
     // matched?

--- a/test/.env
+++ b/test/.env
@@ -16,3 +16,4 @@ RETAIN_INNER_QUOTES={"foo": "bar"}
 RETAIN_INNER_QUOTES_AS_STRING='{"foo": "bar"}'
 INCLUDE_SPACE=some spaced out string
 USERNAME="therealnerdybeast@example.tld"
+export EXPORT_STATEMENT="should be stripped"

--- a/test/main.js
+++ b/test/main.js
@@ -193,5 +193,10 @@ describe('dotenv', function () {
       parsed.should.have.property('USERNAME', 'therealnerdybeast@example.tld')
       done()
     })
+
+    it('remove export statement from beginning', function (done) {
+      parsed.should.have.property('EXPORT_STATEMENT', 'should be stripped')
+      done()
+    })
   })
 })


### PR DESCRIPTION
Dotenv autoloaders like [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh/tree/master/plugins/dotenv) needs the explicit shell export statement at the beginning of the line. This PR handles these .env files as well.