### PR TITLE
Support encrypted .env.crypt files

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,30 @@ control. It should only include environment-specific values such as database
 passwords or API keys. Your production database should have a different
 password than your development database.
 
+### How can I create a version-control-safe `.env` file?
+
+Encrypt your `.env` file as `.env.crypt` and check this file into version
+control, without risk of leaking sensitive details. For this to work, you
+will need to either set the `DOTENVCRYPT` environment variable with your
+decryption password or store the password in a `.env.cryptkey` file that is
+not checked into version control.
+
+If you'd like to use the `DOTENVCRYPT` environment variable, use this:
+
+```shell
+export DOTENVCRYPT='my-secret-password'
+openssl aes-256-cbc    -a -pass env:DOTENVCRYPT -in .env -out .env.crypt  # to encrypt
+openssl aes-256-cbc -d -a -pass env:DOTENVCRYPT -in .env.crypt            # to decrypt
+```
+
+If you'd like to use a `.env.cryptkey` file, use this:
+
+```shell
+echo 'my-secret-password' > .env.cryptkey
+openssl aes-256-cbc    -a -pass file:.env.cryptkey -in .env -out .env.crypt  # to encrypt
+openssl aes-256-cbc -d -a -pass file:.env.cryptkey -in .env.crypt            # to decrypt
+```
+
 ### Should I have multiple `.env` files?
 
 No. We **strongly** recommend against having a "main" `.env` file and an "environment" `.env` file like `.env.test`. Your config should vary between deploys, and you should not be sharing values between environments.

--- a/lib/main.js
+++ b/lib/main.js
@@ -38,6 +38,42 @@ function parse (src) {
   return obj
 }
 
+/* Decrypt an encrypted dotenv file
+ * @param {string} dotenvcryptPath - path to .env.crypt file
+ * @returns {string} decrypted file contents
+*/
+
+function decrypt (dotenvcryptPath) {
+  let file, pass, buff, salt, data, k1, k2, key, iv, aes, out
+  let crypto = require('crypto')
+
+  // read encrypted file and password
+  file = fs.readFileSync(dotenvcryptPath, 'utf8')
+  pass = process.env['DOTENVCRYPT'] || fs.readFileSync(dotenvcryptPath + 'key', 'utf8')
+  pass = pass.replace(/\r?\n.*$/mg, '')
+
+  // read salt and encrypted data
+  buff = new Buffer(file, 'base64')
+  salt = buff.toString('binary', 8, 16)
+  data = buff.toString('binary', 16)
+
+  // construct key components and initialization vector
+  k1 = crypto.createHash('md5').update(     pass + salt, 'binary').digest('binary')
+  k2 = crypto.createHash('md5').update(k1 + pass + salt, 'binary').digest('binary')
+  iv = crypto.createHash('md5').update(k2 + pass + salt, 'binary').digest('binary')
+
+  // construct buffers for the key and initialization vector
+  key = new Buffer(k1 + k2, 'binary')
+  iv  = new Buffer(iv     , 'binary')
+
+  // decrypt the data
+  aes = crypto.createDecipheriv('aes-256-cbc', key, iv)
+  out = aes.update(data, 'binary', 'utf8')
+  out += aes.final('utf8')
+
+  return out
+}
+
 /*
  * Main entry point into dotenv. Allows configuration before loading .env
  * @param {Object} options - options for parsing .env file
@@ -59,8 +95,17 @@ function config (options) {
   }
 
   try {
-    // specifying an encoding returns a string instead of a buffer
-    const parsed = parse(fs.readFileSync(dotenvPath, { encoding }))
+    let source
+    if (!fs.existsSync(dotenvPath           ) &&
+         fs.existsSync(dotenvPath + '.crypt') && (
+         fs.existsSync(dotenvPath + '.cryptkey') ||
+         process.env.hasOwnProperty('DOTENVCRYPT'))) {
+      source = decrypt(dotenvPath + '.crypt')
+    } else {
+      // specifying an encoding returns a string instead of a buffer
+      source = fs.readFileSync(dotenvPath, { encoding })
+    }
+    const parsed = parse(source)
 
     Object.keys(parsed).forEach(function (key) {
       if (!process.env.hasOwnProperty(key)) {


### PR DESCRIPTION
Not sure if this is something that is wanted by others, but it's a helpful way to allow for `.env.crypt` files to be version controlled. In order to use these files, either set the `DOTENVCRYPT` environment variable with the decryption password or store it in a non-version-controlled file called `.env.cryptkey`. I'm not sure if this is of interest to others, or if it would be better to do this as a separate project or even a plugin to the main dotenv project, but I'm submitting it for review if there is interest.