### PR TITLE
Allow to use relative path in dotenv_config_path

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -69,7 +69,7 @@ function config (options) {
   // try to use relative path instead
   try {
     const relativePath = path.resolve(process.cwd(), dotenvPath)
-    _returnParsedFile(relativePath, encoding)
+    return _returnParsedFile(relativePath, encoding)
   } catch (e) {
     return { error }
   }

--- a/lib/main.js
+++ b/lib/main.js
@@ -58,20 +58,38 @@ function config (options) {
     }
   }
 
+  let error = null
   try {
     // specifying an encoding returns a string instead of a buffer
-    const parsed = parse(fs.readFileSync(dotenvPath, { encoding }))
-
-    Object.keys(parsed).forEach(function (key) {
-      if (!process.env.hasOwnProperty(key)) {
-        process.env[key] = parsed[key]
-      }
-    })
-
-    return { parsed }
+    return _returnParsedFile(dotenvPath, encoding)
   } catch (e) {
-    return { error: e }
+    error = e
   }
+
+  // try to use relative path instead
+  try {
+    const relativePath = path.resolve(process.cwd(), dotenvPath)
+    _returnParsedFile(relativePath, encoding)
+  } catch (e) {
+    return { error }
+  }
+}
+
+/**
+ * Return parsed file from incoming parameters
+ * @param {string} dotenvPath - path to .env file
+ * @param {*} encoding - encoding of .env file
+ */
+function _returnParsedFile (dotenvPath, encoding) {
+  const parsed = parse(fs.readFileSync(dotenvPath, { encoding }))
+
+  Object.keys(parsed).forEach(function (key) {
+    if (!process.env.hasOwnProperty(key)) {
+      process.env[key] = parsed[key]
+    }
+  })
+
+  return { parsed }
 }
 
 module.exports.config = config


### PR DESCRIPTION
If file with absolute path is not found, try to use relative path to find env file