### PR TITLE
Fix tests on Windows in node10 branch

### DIFF
--- a/tests/test-config-cli.js
+++ b/tests/test-config-cli.js
@@ -8,9 +8,15 @@ const nodeBinary = process.argv[0]
 test('config preload loads .env', t => {
   t.plan(1)
 
-  // NB: `nodeBinary` is quoted for Windows
-  const stdout = cp.execSync(
-    '"' + nodeBinary + '" -r ../config -e "console.log(process.env.BASIC)" dotenv_config_encoding=utf8',
+  const { stdout } = cp.spawnSync(
+    nodeBinary,
+    [
+      '-r',
+      '../config',
+      '-e',
+      'console.log(process.env.BASIC)',
+      'dotenv_config_encoding=utf8'
+    ],
     {
       cwd: path.resolve(__dirname),
       timeout: 5000,


### PR DESCRIPTION
Fix tests on Windows by avoiding bug in spawn-wrap by using spawnSync instead of execSync

I didn't get to the root of the problem, but I think I've proven that the failing test was due to a bug in tap, probably coming from ['spawn-wrap'](https://github.com/tapjs/spawn-wrap) (a dependency of 'nyc', which is a dependency of 'tap'); both versions of the changed code **should** give the same results, but nah.

In my experiments I found that a number of things would make the tests pass (each on their own):
- Run `npm test` from Hyper terminal instead of Webstorm IDE's terminal or the normal Windows terminal (most confusing, since they all use the cmd.exe shell, and the environment variables were the exact same) 
- disable coverage
- set `nodeBinary` to `'node'` instead of the full path to the node binary (which is what `process.argv[0]` equals here). But this could behave differently depending on the environment PATH.
- use spawnSync instead of execSync (which I've done here)

I'll make a reproduction repo and file a bug in tap (tap, not spawn-wrap, since I don't understand how it all works together) but I think this workaround is acceptable for us.

Feel free to merge or just take what I've learned 🥂 