### PR TITLE
Improve CLI option regex

### DIFF
--- a/lib/cli-options.js
+++ b/lib/cli-options.js
@@ -1,4 +1,4 @@
-const re = /^dotenv_config_(.+)=(.+)/
+const re = /^dotenv_config_(encoding|path)=(.+)$/
 
 module.exports = function optionMatcher (args) {
   return args.reduce(function (acc, cur) {

--- a/tests/test-cli-options.js
+++ b/tests/test-cli-options.js
@@ -2,12 +2,20 @@ const t = require('tap')
 
 const options = require('../lib/cli-options')
 
-t.plan(2)
+t.plan(4)
 
+// matches encoding option
 t.same(options(['node', '-e', "'console.log(testing)'", 'dotenv_config_encoding=utf8']), {
   encoding: 'utf8'
 })
 
+// matches path option
 t.same(options(['node', '-e', "'console.log(testing)'", 'dotenv_config_path=/custom/path/to/your/env/vars']), {
   path: '/custom/path/to/your/env/vars'
 })
+
+// ignores empty values
+t.same(options(['node', '-e', "'console.log(testing)'", 'dotenv_config_path=']), {})
+
+// ignores unsupported options
+t.same(options(['node', '-e', "'console.log(testing)'", 'dotenv_config_foo=bar']), {})

--- a/tests/test-config-cli.js
+++ b/tests/test-config-cli.js
@@ -15,10 +15,11 @@ test('config preload loads .env', t => {
       '../config',
       '-e',
       'console.log(process.env.BASIC)',
-      'dotenv_config_encoding=utf8'
+      'dotenv_config_encoding=utf8',
+      'dotenv_config_path=./tests/.env'
     ],
     {
-      cwd: path.resolve(__dirname),
+      cwd: path.resolve(__dirname, '..'),
       timeout: 5000,
       encoding: 'utf8'
     }


### PR DESCRIPTION
- [x] only accept options we support (encoding and path) #313 
- [x] add test to make sure `dotenv_config_path` is working #321 