### PR TITLE
fix: client side fails to run on IE11 if it requires/imports dotenv 

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -58,7 +58,7 @@ function config (options) {
 
   try {
     // specifying an encoding returns a string instead of a buffer
-    const parsed = parse(fs.readFileSync(dotenvPath, { encoding }))
+    const parsed = parse(fs.readFileSync(dotenvPath, { encoding: encoding }))
 
     Object.keys(parsed).forEach(function (key) {
       if (!process.env.hasOwnProperty(key)) {
@@ -66,7 +66,7 @@ function config (options) {
       }
     })
 
-    return { parsed }
+    return { parsed: parsed }
   } catch (e) {
     return { error: e }
   }


### PR DESCRIPTION
This is happens on create-react-app on dev environment, specifically in IE11, as babel-loader is not set to transpile down any code to ES5 that lies outside the `src` folder. 

These changes will allow for seamless local dev processes on IE11 when using create-react-app and having dotenv as a dependency on client-side code. 