### PR TITLE
add debug option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ You can additionally, pass options to `config`.
 
 Default: `path.resolve(process.cwd(), '.env')`
 
-You can specify a custom path if your file containing environment variables is
+You may specify a custom path if your file containing environment variables is
 named or located differently.
 
 ```js
@@ -109,6 +109,16 @@ using this option.
 require('dotenv').config({ encoding: 'base64' })
 ```
 
+#### Debug
+
+Default: `false`
+
+You may turn on logging to help debug why certain keys or values are not being set as you expect.
+
+```js
+require('dotenv').config({ debug: process.env.DEBUG })
+```
+
 ## Parse
 
 The engine which parses the contents of your file containing environment
@@ -120,6 +130,22 @@ const dotenv = require('dotenv')
 const buf = Buffer.from('BASIC=basic')
 const config = dotenv.parse(buf) // will return an object
 console.log(typeof config, config) // object { BASIC : 'basic' }
+```
+
+### Options
+
+#### Debug
+
+Default: `false`
+
+You may turn on logging to help debug why certain keys or values are not being set as you expect.
+
+```js
+const dotenv = require('dotenv')
+const buf = Buffer.from('hello world')
+const opt = { debug: true }
+const config = dotenv.parse(buf, opt)
+// expect a debug message because the buffer is not in KEY=VAL form
 ```
 
 ### Rules

--- a/lib/cli-options.js
+++ b/lib/cli-options.js
@@ -1,4 +1,4 @@
-const re = /^dotenv_config_(encoding|path)=(.+)$/
+const re = /^dotenv_config_(encoding|path|debug)=(.+)$/
 
 module.exports = function optionMatcher (args) {
   return args.reduce(function (acc, cur) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,16 +1,21 @@
 const fs = require('fs')
 const path = require('path')
 
+function debug (message /*: string */) {
+  console.debug(`[dotenv][DEBUG] ${message}`)
+}
+
 /*
  * Parses a string or buffer into an object
  * @param {(string|Buffer)} src - source to be parsed
  * @returns {Object} keys and values from src
 */
-function parse (src) {
+function parse (src, options) {
+  const debug = options && options.debug
   const obj = {}
 
   // convert Buffers before splitting into lines and processing
-  src.toString().split('\n').forEach(function (line) {
+  src.toString().split('\n').forEach(function (line, idx) {
     // matching "KEY' and 'VAL' in 'KEY=VAL'
     const keyValueArr = line.match(/^\s*([\w.-]+)\s*=\s*(.*)?\s*$/)
     // matched?
@@ -30,6 +35,8 @@ function parse (src) {
       value = value.replace(/(^['"]|['"]$)/g, '').trim()
 
       obj[key] = value
+    } else if (debug) {
+      debug(`did not match key and value when parsing line ${idx + 1}: ${line}`)
     }
   })
 
@@ -41,11 +48,13 @@ function parse (src) {
  * @param {Object} options - options for parsing .env file
  * @param {string} [options.path=.env] - path to .env file
  * @param {string} [options.encoding=utf8] - encoding of .env file
+ * @param {boolean} [options.debug=false] - turn on logging for debugging purposes
  * @returns {Object} parsed object or error
 */
 function config (options) {
   let dotenvPath = path.resolve(process.cwd(), '.env')
   let encoding = 'utf8'
+  let debug = false
 
   if (options) {
     if (options.path) {
@@ -54,15 +63,20 @@ function config (options) {
     if (options.encoding) {
       encoding = options.encoding
     }
+    if (options.debug) {
+      debug = true
+    }
   }
 
   try {
     // specifying an encoding returns a string instead of a buffer
-    const parsed = parse(fs.readFileSync(dotenvPath, { encoding }))
+    const parsed = parse(fs.readFileSync(dotenvPath, { encoding }), { debug })
 
     Object.keys(parsed).forEach(function (key) {
       if (!process.env.hasOwnProperty(key)) {
         process.env[key] = parsed[key]
+      } else if (debug) {
+        debug(`"${key}" is already defined in \`process.env\` and will not be overwritten`)
       }
     })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,13 +50,10 @@
       }
     },
     "@sinonjs/samsam": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.1.tgz",
-      "integrity": "sha512-7oX6PXMulvdN37h88dvlvRyu61GYZau40fL4wEZvPEHvrjpJc3lDv6xDM5n4Z0StufUVB5nDvVZUM+jZHdMOOQ==",
-      "dev": true,
-      "requires": {
-        "array-from": "^2.1.1"
-      }
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.2.tgz",
+      "integrity": "sha512-ZwTHAlC9akprWDinwEPD4kOuwaYZlyMwVJIANsKNC3QVp0AHB04m7RnB4eqeWfgmxw8MGTzS9uMaw93Z3QcZbw==",
+      "dev": true
     },
     "acorn": {
       "version": "5.7.3",
@@ -237,7 +234,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -250,7 +247,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -1247,7 +1244,7 @@
     },
     "external-editor": {
       "version": "2.2.0",
-      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
@@ -1805,7 +1802,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -2113,7 +2110,7 @@
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
@@ -5705,17 +5702,17 @@
       "dev": true
     },
     "sinon": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.3.4.tgz",
-      "integrity": "sha512-NIaR56Z1mefuRBXYrf4otqBxkWiKveX+fvqs3HzFq2b07HcgpkMgIwmQM/owNjNFAHkx0kJXW+Q0mDthiuslXw==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.3.5.tgz",
+      "integrity": "sha512-xgoZ2gKjyVRcF08RrIQc+srnSyY1JDJtxu3Nsz07j1ffjgXoY6uPLf/qja6nDBZgzYYEovVkFryw2+KiZz11xQ==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.0.2",
         "@sinonjs/formatio": "^3.0.0",
-        "@sinonjs/samsam": "^2.1.1",
+        "@sinonjs/samsam": "^2.1.2",
         "diff": "^3.5.0",
         "lodash.get": "^4.4.2",
-        "lolex": "^2.7.4",
+        "lolex": "^2.7.5",
         "nise": "^1.4.5",
         "supports-color": "^5.5.0",
         "type-detect": "^4.0.8"
@@ -6267,7 +6264,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "readmeFilename": "README.md",
   "license": "BSD-2-Clause",
   "devDependencies": {
-    "sinon": "^6.3.4",
+    "sinon": "^6.3.5",
     "standard": "^12.0.1",
     "standard-markdown": "^5.0.1",
     "tap": "^12.0.1"

--- a/tests/test-cli-options.js
+++ b/tests/test-cli-options.js
@@ -2,7 +2,7 @@ const t = require('tap')
 
 const options = require('../lib/cli-options')
 
-t.plan(4)
+t.plan(5)
 
 // matches encoding option
 t.same(options(['node', '-e', "'console.log(testing)'", 'dotenv_config_encoding=utf8']), {
@@ -12,6 +12,11 @@ t.same(options(['node', '-e', "'console.log(testing)'", 'dotenv_config_encoding=
 // matches path option
 t.same(options(['node', '-e', "'console.log(testing)'", 'dotenv_config_path=/custom/path/to/your/env/vars']), {
   path: '/custom/path/to/your/env/vars'
+})
+
+// matches debug option
+t.same(options(['node', '-e', "'console.log(testing)'", 'dotenv_config_debug=true']), {
+  debug: 'true'
 })
 
 // ignores empty values

--- a/tests/test-config-cli.js
+++ b/tests/test-config-cli.js
@@ -16,7 +16,8 @@ test('config preload loads .env', t => {
       '-e',
       'console.log(process.env.BASIC)',
       'dotenv_config_encoding=utf8',
-      'dotenv_config_path=./tests/.env'
+      'dotenv_config_path=./tests/.env',
+      'dotenv_config_debug=true'
     ],
     {
       cwd: path.resolve(__dirname, '..'),

--- a/tests/test-config.js
+++ b/tests/test-config.js
@@ -1,7 +1,7 @@
 const fs = require('fs')
 
-const t = require('tap')
 const sinon = require('sinon')
+const t = require('tap')
 
 const dotenv = require('../lib/main')
 
@@ -38,12 +38,22 @@ t.test('takes option for encoding', ct => {
   ct.equal(readFileSyncStub.args[0][1].encoding, testEncoding)
 })
 
+t.test('takes option for debug', ct => {
+  ct.plan(1)
+
+  const warnStub = sinon.stub(console, 'warn')
+  dotenv.config({ debug: true })
+
+  ct.ok(warnStub.called)
+  warnStub.restore()
+})
+
 t.test('reads path with encoding, parsing output to process.env', ct => {
   ct.plan(2)
 
   const res = dotenv.config()
-  ct.same(res.parsed, mockParseResponse)
 
+  ct.same(res.parsed, mockParseResponse)
   ct.equal(readFileSyncStub.callCount, 1)
 })
 
@@ -51,6 +61,7 @@ t.test('makes load a synonym of config', ct => {
   ct.plan(2)
 
   const env = dotenv.load()
+
   ct.same(env.parsed, mockParseResponse)
   ct.equal(readFileSyncStub.callCount, 1)
 })

--- a/tests/test-parse.js
+++ b/tests/test-parse.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
 
+const sinon = require('sinon')
 const t = require('tap')
 
 const dotenv = require('../lib/main')
@@ -7,7 +8,7 @@ const dotenv = require('../lib/main')
 process.env.TEST = 'test'
 const parsed = dotenv.parse(fs.readFileSync('tests/.env', { encoding: 'utf8' }))
 
-t.plan(16)
+t.plan(17)
 
 t.type(parsed, Object, 'should return an object')
 
@@ -41,3 +42,9 @@ t.equal(parsed['USERNAME'], 'therealnerdybeast@example.tld', 'parses email addre
 
 const payload = dotenv.parse(Buffer.from('BASIC=basic'))
 t.equal(payload.BASIC, 'basic', 'should parse a buffer from a file into an object')
+
+// test debug path
+const warnStub = sinon.stub(console, 'warn')
+dotenv.parse(Buffer.from('what is this'), { debug: true })
+t.ok(warnStub.called)
+warnStub.restore()


### PR DESCRIPTION
Every so often [issues like this](
https://github.com/motdotla/dotenv/issues/128#issuecomment-424429739) arise where people don't realize a certain key already exists and won't be overwritten or maybe a line in their `.env` file is malformed. Adding a "debug" option should allow people to catch these things earlier.

This is a simple extension of the current options and keeps `dotenv` dependency free by just using `console.debug` (an alias for `console.log`)