### PR TITLE
Allow configure dotenv via existing environment variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ The configuration options below are supported as command line arguments in the f
 $ node -r dotenv/config your_script.js dotenv_config_path=/custom/path/to/your/env/vars
 ```
 
+Also the configuration options can be taken from already existing environment variables in the format `DOTENV_CONFIG_<OPTION>=value`
+```dotenv
+DOTENV_CONFIG_PATH=/custom/path/to/your/env/vars
+```
+
 ## Config
 
 _Alias: `load`_

--- a/lib/main.js
+++ b/lib/main.js
@@ -44,8 +44,8 @@ function parse (src) {
  * @returns {Object} parsed object or error
 */
 function config (options) {
-  let dotenvPath = path.resolve(process.cwd(), '.env')
-  let encoding = 'utf8'
+  let dotenvPath = path.resolve(process.cwd(), process.env.DOTENV_CONFIG_PATH || '.env')
+  let encoding = process.env.DOTENV_CONFIG_ENCODING || 'utf8'
 
   if (options) {
     if (options.path) {

--- a/tests/test-config-env.js
+++ b/tests/test-config-env.js
@@ -1,0 +1,64 @@
+const fs = require('fs')
+const path = require('path')
+
+const t = require('tap')
+const sinon = require('sinon')
+
+const dotenv = require('../lib/main')
+
+const mockParseResponse = { test: 'foo' }
+
+let readFileSyncStub
+let existingDotEnvPath
+let existingDotEnvEncoding
+
+t.beforeEach(done => {
+  existingDotEnvEncoding = process.env.DOTENV_CONFIG_ENCODING
+  existingDotEnvPath = process.env.DOTENV_CONFIG_PATH
+
+  readFileSyncStub = sinon.stub(fs, 'readFileSync').returns('test=foo')
+  sinon.stub(dotenv, 'parse').returns(mockParseResponse)
+  done()
+})
+
+t.afterEach(done => {
+  readFileSyncStub.restore()
+  dotenv.parse.restore()
+
+  process.env.DOTENV_CONFIG_PATH = existingDotEnvPath
+  process.env.DOTENV_CONFIG_ENCODING = existingDotEnvEncoding
+  done()
+})
+
+t.test('takes relative path to dotenv file from env', ct => {
+  ct.plan(1)
+
+  const testPath = 'tests/.env2'
+  const expectedPath = path.resolve(process.cwd(), testPath)
+
+  process.env.DOTENV_CONFIG_PATH = testPath
+  dotenv.config()
+
+  ct.equal(readFileSyncStub.args[0][0], expectedPath)
+})
+
+t.test('takes absolute path to dotenv file from env', ct => {
+  ct.plan(1)
+
+  const testPath = '/tmp/.env2'
+
+  process.env.DOTENV_CONFIG_PATH = testPath
+  dotenv.config()
+
+  ct.equal(readFileSyncStub.args[0][0], testPath)
+})
+
+t.test('takes encoding for dotenv file from env', ct => {
+  ct.plan(1)
+
+  const testEncoding = 'base64'
+  process.env.DOTENV_CONFIG_ENCODING = testEncoding
+  dotenv.config()
+
+  ct.equal(readFileSyncStub.args[0][1].encoding, testEncoding)
+})

--- a/tests/test-config-env.js
+++ b/tests/test-config-env.js
@@ -46,11 +46,12 @@ t.test('takes absolute path to dotenv file from env', ct => {
   ct.plan(1)
 
   const testPath = '/tmp/.env2'
+  const expectedPath = path.resolve(process.cwd(), testPath)
 
   process.env.DOTENV_CONFIG_PATH = testPath
   dotenv.config()
 
-  ct.equal(readFileSyncStub.args[0][0], testPath)
+  ct.equal(readFileSyncStub.args[0][0], expectedPath)
 })
 
 t.test('takes encoding for dotenv file from env', ct => {

--- a/tests/test-config-env.js
+++ b/tests/test-config-env.js
@@ -42,10 +42,22 @@ t.test('takes relative path to dotenv file from env', ct => {
   ct.equal(readFileSyncStub.args[0][0], expectedPath)
 })
 
-t.test('takes absolute path to dotenv file from env', ct => {
+t.test('takes absolute unix path to dotenv file from env', ct => {
   ct.plan(1)
 
   const testPath = '/tmp/.env2'
+  const expectedPath = path.resolve(process.cwd(), testPath)
+
+  process.env.DOTENV_CONFIG_PATH = testPath
+  dotenv.config()
+
+  ct.equal(readFileSyncStub.args[0][0], expectedPath)
+})
+
+t.test('takes absolute windows path to dotenv file from env', ct => {
+  ct.plan(1)
+
+  const testPath = 'C:\\temp\\.env2'
   const expectedPath = path.resolve(process.cwd(), testPath)
 
   process.env.DOTENV_CONFIG_PATH = testPath


### PR DESCRIPTION
This is a very useful feature in a cases when .env file is located in different places on different servers 
or testing server has its own specific .env file commited to VCS etc.