### PR TITLE
Set dotenv_config_* vars via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ The configuration options below are supported as command line arguments in the f
 $ node -r dotenv/config your_script.js dotenv_config_path=/custom/path/to/your/env/vars
 ```
 
-Note, some IDEs like Webstorm and IntellJ might have trouble properly passing `dotenv_config_path` to node. This does not impact command line use, just when configuring run options within the IDE. 
-As an alternative for this situation, you can also set `dotenv_config_path` as an environment variable in your IDE run configuration instead of as a command line argument  
+If you are having trouble passing the `dotenv_config_<option>=value` part via the CLI, you can use environment variables instead. When using environment variables, be sure to use uppercase names, `DOTENV_CONFIG_<OPTION>=value`. 
+  
 
 ## Config
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ The configuration options below are supported as command line arguments in the f
 $ node -r dotenv/config your_script.js dotenv_config_path=/custom/path/to/your/env/vars
 ```
 
+Note, some IDEs like Webstorm and IntellJ might have trouble properly passing `dotenv_config_path` to node. This does not impact command line use, just when configuring run options within the IDE. 
+As an alternative for this situation, you can also set `dotenv_config_path` as an environment variable in your IDE run configuration instead of as a command line argument  
+
 ## Config
 
 _Alias: `load`_

--- a/config.js
+++ b/config.js
@@ -2,6 +2,9 @@
 
 (function () {
   require('./lib/main').config(
-    require('./lib/cli-options')(process.argv)
+    {
+      ...require('./lib/cli-options')(process.argv),
+      ...require('./lib/env-options')()
+    }
   )
 })()

--- a/config.js
+++ b/config.js
@@ -2,9 +2,6 @@
 
 (function () {
   require('./lib/main').config(
-    {
-      ...require('./lib/cli-options')(process.argv),
-      ...require('./lib/env-options')()
-    }
+    Object.assign({}, require('./lib/env-options'), require('./lib/cli-options')(process.argv))
   )
 })()

--- a/config.js
+++ b/config.js
@@ -2,6 +2,6 @@
 
 (function () {
   require('./lib/main').config(
-    Object.assign({}, require('./lib/env-options'), require('./lib/cli-options')(process.argv))
+    Object.assign({}, require('./lib/env-options')(process.env), require('./lib/cli-options')(process.argv))
   )
 })()

--- a/lib/env-options.js
+++ b/lib/env-options.js
@@ -1,0 +1,13 @@
+/* @flow */
+
+const re = /^dotenv_config_(encoding|path|debug)$/
+
+module.exports = function optionMatcher () {
+  return Object.entries(process.env).reduce(function (acc, [key, val]) {
+    const matches = key.match(re)
+    if (matches) {
+      acc[matches[1]] = val
+    }
+    return acc
+  }, {})
+}

--- a/lib/env-options.js
+++ b/lib/env-options.js
@@ -1,7 +1,9 @@
 /* @flow */
 
-module.exports = {
-  encoding: process.env.dotenv_config_encoding,
-  path: process.env.dotenv_config_path,
-  debug: process.env.dotenv_config_debug
+module.exports = function (env = {}) {
+  return Object.assign({},
+    env.DOTENV_CONFIG_ENCODING ? { encoding: env.DOTENV_CONFIG_ENCODING } : null,
+    env.DOTENV_CONFIG_PATH ? { path: env.DOTENV_CONFIG_PATH } : null,
+    env.DOTENV_CONFIG_DEBUG ? { debug: env.DOTENV_CONFIG_DEBUG } : null
+  )
 }

--- a/lib/env-options.js
+++ b/lib/env-options.js
@@ -1,13 +1,7 @@
 /* @flow */
 
-const re = /^dotenv_config_(encoding|path|debug)$/
-
-module.exports = function optionMatcher () {
-  return Object.entries(process.env).reduce(function (acc, [key, val]) {
-    const matches = key.match(re)
-    if (matches) {
-      acc[matches[1]] = val
-    }
-    return acc
-  }, {})
+module.exports = {
+  encoding: process.env.dotenv_config_encoding,
+  path: process.env.dotenv_config_path,
+  debug: process.env.dotenv_config_debug
 }

--- a/tests/test-env-options.js
+++ b/tests/test-env-options.js
@@ -1,0 +1,29 @@
+/* @flow */
+
+const t = require('tap')
+
+const options = require('../lib/env-options')
+
+t.plan(6)
+
+// matches encoding option
+t.same(options({ DOTENV_CONFIG_ENCODING: 'utf8' }), {
+  encoding: 'utf8'
+})
+
+// matches path option
+t.same(options({ DOTENV_CONFIG_PATH: '/custom/path/to/your/env/vars' }), {
+  path: '/custom/path/to/your/env/vars'
+})
+
+// matches debug option
+t.same(options({ DOTENV_CONFIG_DEBUG: 'true' }), {
+  debug: 'true'
+})
+
+// ignores empty values
+t.same(options(), {})
+t.same(options({}), {})
+
+// ignores unsupported options
+t.same(options({ DOTENV_CONFIG_FOO: 'foo' }), {})


### PR DESCRIPTION
Now `dotenv_config_*` can be supplied in a system env var instead of in CLI command.

Helps some IDEs that get confused with the CLI option like WebStorm/IntelliJ. WebStorm’s application of those command line config options was resulting in node trying to load them as additional npm modules rather than simple argv options that dotenv would consume.