### PR TITLE
Custom parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,20 @@ You may turn on logging to help debug why certain keys or values are not being s
 require('dotenv').config({ debug: process.env.DEBUG })
 ```
 
+#### Parser
+
+You may implement your own parser, this can be useful for different env 
+file formats e.g. JSON. Dotenv will work as long as custom parser 
+returns object in expected format `{ KEY: 'value', KEY1: 'value1' }`. 
+Check default `parse` function for the reference.
+
+```js
+const customParser = function (src, options) {
+  return JSON.parse(src)
+}
+require('dotenv').config({ path: '.env.json', parser: customParser })
+```
+
 ## Parse
 
 The engine which parses the contents of your file containing environment

--- a/lib/main.js
+++ b/lib/main.js
@@ -11,7 +11,8 @@ type DotenvParseOutput = { [string]: string }
 type DotenvConfigOptions = {
   path?: string, // path to .env file
   encoding?: string, // encoding of .env file
-  debug?: string // turn on logging for debugging purposes
+  debug?: string, // turn on logging for debugging purposes
+  parser?: function // set custom parser
 }
 
 type DotenvConfigOutput = {
@@ -67,6 +68,7 @@ function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ 
   let dotenvPath = path.resolve(process.cwd(), '.env')
   let encoding /*: string */ = 'utf8'
   let debug = false
+  let parser = parse
 
   if (options) {
     if (options.path != null) {
@@ -78,11 +80,14 @@ function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ 
     if (options.debug != null) {
       debug = true
     }
+    if (options.parser != null) {
+      parser = options.parser
+    }
   }
 
   try {
     // specifying an encoding returns a string instead of a buffer
-    const parsed = parse(fs.readFileSync(dotenvPath, { encoding }), { debug })
+    const parsed = parser(fs.readFileSync(dotenvPath, { encoding }), { debug })
 
     Object.keys(parsed).forEach(function (key) {
       if (!process.env.hasOwnProperty(key)) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -12,7 +12,7 @@ type DotenvConfigOptions = {
   path?: string, // path to .env file
   encoding?: string, // encoding of .env file
   debug?: string, // turn on logging for debugging purposes
-  parser?: (str: string, options: DotenvParseOptions) => { [string]: string }
+  parser?: (str: string, options: DotenvParseOptions) => DotenvParseOutput
 }
 
 type DotenvConfigOutput = {

--- a/lib/main.js
+++ b/lib/main.js
@@ -12,7 +12,7 @@ type DotenvConfigOptions = {
   path?: string, // path to .env file
   encoding?: string, // encoding of .env file
   debug?: string, // turn on logging for debugging purposes
-  parser?: function // set custom parser
+  parser?: (str: string, options: DotenvParseOptions) => { [string]: string }
 }
 
 type DotenvConfigOutput = {

--- a/tests/test-config-parser.js
+++ b/tests/test-config-parser.js
@@ -1,0 +1,24 @@
+/* @flow */
+
+const fs = require('fs')
+
+const sinon = require('sinon')
+const t = require('tap')
+
+const dotenv = require('../lib/main')
+
+t.plan(1)
+
+t.test('takes option for parser', ct => {
+  ct.plan(1)
+
+  const testPath = 'tests/.env.json'
+  const customParser = function (src, options) {
+    return JSON.parse(src)
+  }
+
+  sinon.stub(fs, 'readFileSync').returns('{"test": "foo"}')
+  const res = dotenv.config({ path: testPath, parser: customParser })
+
+  ct.equal(res.parsed.test, 'foo')
+})


### PR DESCRIPTION
As mentioned in #364, this minimalist adjustment allows to pass custom parser to the `config` function.  Then, dotenv will be able to handle cutom data types such as JSON. Default behavior of library **does not change**. 