### PR TITLE
clarify encoding usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $ DOTENV_CONFIG_<OPTION>=value node -r dotenv/config your_script.js
 ```
 
 ```bash
-$ DOTENV_CONFIG_ENCODING=base64 node -r dotenv/config your_script.js dotenv_config_path=/custom/path/to/.env
+$ DOTENV_CONFIG_ENCODING=latin1 node -r dotenv/config your_script.js dotenv_config_path=/custom/path/to/.env
 ```
 
 ## Config
@@ -114,7 +114,7 @@ Default: `utf8`
 You may specify the encoding of your file containing environment variables.
 
 ```js
-require('dotenv').config({ encoding: 'base64' })
+require('dotenv').config({ encoding: 'latin1' })
 ```
 
 #### Debug

--- a/tests/test-config.js
+++ b/tests/test-config.js
@@ -37,7 +37,7 @@ t.test('takes option for path', ct => {
 t.test('takes option for encoding', ct => {
   ct.plan(1)
 
-  const testEncoding = 'base64'
+  const testEncoding = 'latin1'
   dotenv.config({ encoding: testEncoding })
 
   ct.equal(readFileSyncStub.args[0][1].encoding, testEncoding)

--- a/tests/test-env-options.js
+++ b/tests/test-env-options.js
@@ -36,7 +36,7 @@ delete process.env.DOTENV_CONFIG_DEBUG
 t.same(options(), {})
 
 // sets encoding option
-testOption('DOTENV_CONFIG_ENCODING', 'base64', { encoding: 'base64' })
+testOption('DOTENV_CONFIG_ENCODING', 'latin1', { encoding: 'latin1' })
 
 // sets path option
 testOption('DOTENV_CONFIG_PATH', '~/.env.test', { path: '~/.env.test' })


### PR DESCRIPTION
#363 likely arose from misleading documentation. updating docs and tests to use an encoding besides `utf8` that should still parse