### PR TITLE
feat: support for overriding environment vars. fix #199

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,23 @@ You may specify the encoding of your file containing environment variables.
 require('dotenv').config({ encoding: 'latin1' })
 ```
 
+#### Override
+
+Default: `false`
+
+When set to `true`, the environment variables from your env file override what is set in `process.env`.
+
+```txt
+# .env
+PORT=8080
+```
+
+```js
+process.env['PORT'] = '3000'
+require('dotenv').config({ override: true })
+console.log(process.env['PORT']) // prints 8080
+```
+
 #### Debug
 
 Default: `false`
@@ -194,17 +211,14 @@ No. We **strongly** recommend against having a "main" `.env` file and an "enviro
 
 ### What happens to environment variables that were already set?
 
-We will never modify any environment variables that have already been set. In particular, if there is a variable in your `.env` file which collides with one that already exists in your environment, then that variable will be skipped. This behavior allows you to override all `.env` configurations with a machine-specific environment, although it is not recommended.
+By default we will never modify any environment variables that have already been set. In particular, if there is a variable in your `.env` file which collides with one that already exists in your environment, then that variable will be skipped. If you want to override it you can set the `override` option for `config()` function to `true`. This behavior allows you to override all `.env` configurations with a machine-specific environment, although it is not recommended.
 
 If you want to override `process.env` you can do something like this:
 
 ```javascript
 const fs = require('fs')
 const dotenv = require('dotenv')
-const envConfig = dotenv.parse(fs.readFileSync('.env.override'))
-for (let k in envConfig) {
-  process.env[k] = envConfig[k]
-}
+const envConfig = dotenv.config({ override: true })
 ```
 
 ### Can I customize/write plugins for dotenv?

--- a/lib/main.js
+++ b/lib/main.js
@@ -11,6 +11,7 @@ type DotenvParseOutput = { [string]: string }
 type DotenvConfigOptions = {
   path?: string, // path to .env file
   encoding?: string, // encoding of .env file
+  override?: boolean, // whether values from .env should override process.env
   debug?: string // turn on logging for debugging purposes
 }
 
@@ -66,6 +67,7 @@ function parse (src /*: string | Buffer */, options /*: ?DotenvParseOptions */) 
 function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ {
   let dotenvPath = path.resolve(process.cwd(), '.env')
   let encoding /*: string */ = 'utf8'
+  let override = false
   let debug = false
 
   if (options) {
@@ -74,6 +76,9 @@ function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ 
     }
     if (options.encoding != null) {
       encoding = options.encoding
+    }
+    if (options.override != null) {
+      override = true
     }
     if (options.debug != null) {
       debug = true
@@ -85,7 +90,7 @@ function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ 
     const parsed = parse(fs.readFileSync(dotenvPath, { encoding }), { debug })
 
     Object.keys(parsed).forEach(function (key) {
-      if (!process.env.hasOwnProperty(key)) {
+      if (override || !process.env.hasOwnProperty(key)) {
         process.env[key] = parsed[key]
       } else if (debug) {
         log(`"${key}" is already defined in \`process.env\` and will not be overwritten`)

--- a/tests/test-config.js
+++ b/tests/test-config.js
@@ -11,7 +11,7 @@ const mockParseResponse = { test: 'foo' }
 let readFileSyncStub
 let parseStub
 
-t.plan(9)
+t.plan(10)
 
 t.beforeEach(done => {
   readFileSyncStub = sinon.stub(fs, 'readFileSync').returns('test=foo')
@@ -41,6 +41,18 @@ t.test('takes option for encoding', ct => {
   dotenv.config({ encoding: testEncoding })
 
   ct.equal(readFileSyncStub.args[0][1].encoding, testEncoding)
+})
+
+t.test('overrides the value in process.env if override option is truthy', ct => {
+  ct.plan(2)
+
+  const existing = 'bar'
+  process.env.test = existing
+  // 'foo' returned as value in `beforeEach`. should keep this 'bar'
+  const env = dotenv.config({ override: true })
+
+  ct.equal(env.parsed && env.parsed.test, mockParseResponse.test)
+  ct.equal(process.env.test, 'foo')
 })
 
 t.test('takes option for debug', ct => {


### PR DESCRIPTION
This PR adds support for an `override` option to `config()` that is false by default.

The truth is that the workaround suggested [here](https://github.com/motdotla/dotenv#what-happens-to-environment-variables-that-were-already-set) is not the most elegant way of solving the problem and creates a messy [`setupfilesafterenv`](https://jestjs.io/docs/en/configuration.html#setupfilesafterenv-array) script in `jest`. This could easily be avoided if this feature was natively supported.
This feature is popularly demanded (https://github.com/motdotla/dotenv/issues/199) and can be great to add it.

I've updated the documentations with an example.
Also I've added tests with 100% coverage.