### PR TITLE
Add a callback to parse().

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -29,7 +29,7 @@ function log (message /*: string */) {
 }
 
 // Parses src into an Object
-function parse (src /*: string | Buffer */, options /*: ?DotenvParseOptions */) /*: DotenvParseOutput */ {
+function parse (src /*: string | Buffer */, options /*: ?DotenvParseOptions */, itemCallback) /*: DotenvParseOutput */ {
   const debug = Boolean(options && options.debug)
   const obj = {}
 
@@ -52,6 +52,13 @@ function parse (src /*: string | Buffer */, options /*: ?DotenvParseOptions */) 
 
       // remove any surrounding quotes and extra spaces
       value = value.replace(/(^['"]|['"]$)/g, '').trim()
+
+      if (itemCallback) {
+        value = itemCallback(key, value)
+        if (!value) {
+          return
+        }
+      }
 
       obj[key] = value
     } else if (debug) {

--- a/tests/test-parse.js
+++ b/tests/test-parse.js
@@ -8,9 +8,9 @@ const t = require('tap')
 const dotenv = require('../lib/main')
 
 process.env.TEST = 'test'
-const parsed = dotenv.parse(fs.readFileSync('tests/.env', { encoding: 'utf8' }))
+let parsed = dotenv.parse(fs.readFileSync('tests/.env', { encoding: 'utf8' }))
 
-t.plan(17)
+t.plan(21)
 
 t.type(parsed, Object, 'should return an object')
 
@@ -44,6 +44,25 @@ t.equal(parsed['USERNAME'], 'therealnerdybeast@example.tld', 'parses email addre
 
 const payload = dotenv.parse(Buffer.from('BASIC=basic'))
 t.equal(payload.BASIC, 'basic', 'should parse a buffer from a file into an object')
+
+// test callback
+
+parsed = dotenv.parse(fs.readFileSync('tests/.env', { encoding: 'utf8' }), {}, (k, v) => {
+  if (k === 'USERNAME') {
+    return undefined
+  }
+  if (v === '') {
+    return '""'
+  }
+  if (v !== '' && v[0] === 'b') {
+    return '<' + v + '>'
+  }
+  return v
+})
+t.equal(parsed.BASIC, '<basic>', 'sets basic environment variable')
+t.equal(parsed.EMPTY, '""', 'defaults empty values to empty string')
+t.notOk(parsed.USERNAME, 'var not removed')
+t.equal(parsed.INCLUDE_SPACE, 'some spaced out string', 'retains spaces in string')
 
 // test debug path
 const logStub = sinon.stub(console, 'log')


### PR DESCRIPTION
There are a couple of use cases in which `dotenv.parse()` doesn't quite meet my needs:
* when I need to see the value from each valid line; sometimes an env var is set multiple times but currently I only get the last entry (I need them all)
* when the the order from the `.env` file matters

This change addresses those by adding a callback to `parse()` which gets called with the key/value pair for each valid env var line.  This could also be done with [an iterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#Iterators) that gives the key/value pairs (and `parse()` would use that), but a callback seemed simpler.