### PR TITLE
Be strict about env var names.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -36,7 +36,7 @@ function parse (src /*: string | Buffer */, options /*: ?DotenvParseOptions */) 
   // convert Buffers before splitting into lines and processing
   src.toString().split('\n').forEach(function (line, idx) {
     // matching "KEY' and 'VAL' in 'KEY=VAL'
-    const keyValueArr = line.match(/^\s*([\w.-]+)\s*=\s*(.*)?\s*$/)
+    const keyValueArr = line.match(/^\s*([a-zA-Z]\w*)\s*=\s*(.*)?\s*$/)
     // matched?
     if (keyValueArr != null) {
       const key = keyValueArr[1]


### PR DESCRIPTION
Currently `dotenv.parse()` allows environment variable names which aren't actually valid for environment variables.  This change ensures that they are.