### PR TITLE
Make value capture is non-greedy.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -36,7 +36,7 @@ function parse (src /*: string | Buffer */, options /*: ?DotenvParseOptions */) 
   // convert Buffers before splitting into lines and processing
   src.toString().split('\n').forEach(function (line, idx) {
     // matching "KEY' and 'VAL' in 'KEY=VAL'
-    const keyValueArr = line.match(/^\s*([\w.-]+)\s*=\s*(.*)?\s*$/)
+    const keyValueArr = line.match(/^\s*([\w.-]+)\s*=\s*(.*?)?\s*$/)
     // matched?
     if (keyValueArr != null) {
       const key = keyValueArr[1]


### PR DESCRIPTION
The value part of the regex in `dotenv.parse()` currently captures spaces.  This change adds an "?" (non-greedy modifier) to the regex to ensure it doesn't.