### PR TITLE
Sort out quotation mark handling.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -44,14 +44,15 @@ function parse (src /*: string | Buffer */, options /*: ?DotenvParseOptions */) 
       // default undefined or missing values to empty string
       let value = keyValueArr[2] || ''
 
+      // remove any surrounding quotes
       // expand newlines in quoted values
       const len = value ? value.length : 0
       if (len > 0 && value.charAt(0) === '"' && value.charAt(len - 1) === '"') {
+        value = value.substring(1, len - 1)
         value = value.replace(/\\n/gm, '\n')
+      } else if (len > 0 && value.charAt(0) === '\'' && value.charAt(len - 1) === '\'') {
+        value = value.substring(1, len - 1)
       }
-
-      // remove any surrounding quotes and extra spaces
-      value = value.replace(/(^['"]|['"]$)/g, '').trim()
 
       obj[key] = value
     } else if (debug) {


### PR DESCRIPTION
Quotation mark handling in `dotenv.parse()` currently has a couple of small problems:
* leading marks without trailing marks (and vice versa) are still removed
* whitespace inside balanced (outer) quotation marks is removed, defeating part of the point of the quotation marks

This change corrects both.