### PR TITLE
ft: add a config option to toggle usage of process.env

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Dotenv is a zero-dependency module that loads environment variables from a `.env
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/feross/standard)
 [![Coverage Status](https://img.shields.io/coveralls/motdotla/dotenv/master.svg?style=flat-square)](https://coveralls.io/github/motdotla/dotenv?branch=coverall-intergration)
 
+# Update
+ - Added a config option `returnProcess: true | false` to return `process.env` or not. Suitable if you are abstracting your config not to use `process.env` everywhere
+
 ## Install
 
 ```bash

--- a/lib/main.js
+++ b/lib/main.js
@@ -31,7 +31,7 @@ function log (message /*: string */) {
 // Parses src into an Object
 function parse (src /*: string | Buffer */, options /*: ?DotenvParseOptions */) /*: DotenvParseOutput */ {
   const debug = Boolean(options && options.debug)
-  const obj = {}
+  let obj = {}
 
   // convert Buffers before splitting into lines and processing
   src.toString().split('\n').forEach(function (line, idx) {
@@ -59,6 +59,10 @@ function parse (src /*: string | Buffer */, options /*: ?DotenvParseOptions */) 
     }
   })
 
+  if(options.returnProcess) {
+    obj = process.env;
+  }
+
   return obj
 }
 
@@ -82,7 +86,7 @@ function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ 
 
   try {
     // specifying an encoding returns a string instead of a buffer
-    const parsed = parse(fs.readFileSync(dotenvPath, { encoding }), { debug })
+    let parsed = parse(fs.readFileSync(dotenvPath, { encoding }), { debug })
 
     Object.keys(parsed).forEach(function (key) {
       if (!process.env.hasOwnProperty(key)) {
@@ -91,6 +95,10 @@ function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ 
         log(`"${key}" is already defined in \`process.env\` and will not be overwritten`)
       }
     })
+
+    if(options.returnProcess) {
+      parsed = process.env;
+    }
 
     return { parsed }
   } catch (e) {


### PR DESCRIPTION
This PR adds a config option `returnProcess` to determine whether to use process.env or not.

This is suitable if you have a config module to abstract environment variables so as not to pollute the global scope with process.env and want it to work both in development and production