### PR TITLE
Support overwriting keys

### DIFF
--- a/lib/cli-options.js
+++ b/lib/cli-options.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-const re = /^dotenv_config_(encoding|path|debug)=(.+)$/
+const re = /^dotenv_config_(encoding|path|debug|overwrite)=(.+)$/
 
 module.exports = function optionMatcher (args /*: Array<string> */) {
   return args.reduce(function (acc, cur) {

--- a/lib/env-options.js
+++ b/lib/env-options.js
@@ -15,4 +15,8 @@ if (process.env.DOTENV_CONFIG_DEBUG != null) {
   options.debug = process.env.DOTENV_CONFIG_DEBUG
 }
 
+if (process.env.DOTENV_CONFIG_OVERWRITE != null) {
+  options.overwrite = process.env.DOTENV_CONFIG_OVERWRITE
+}
+
 module.exports = options

--- a/lib/main.js
+++ b/lib/main.js
@@ -77,6 +77,7 @@ function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ 
   let dotenvPath = path.resolve(process.cwd(), '.env')
   let encoding /*: string */ = 'utf8'
   let debug = false
+  let overwrite = false
 
   if (options) {
     if (options.path != null) {
@@ -88,6 +89,9 @@ function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ 
     if (options.debug != null) {
       debug = true
     }
+    if (options.overwrite != null) {
+      overwrite = true
+    }
   }
 
   try {
@@ -95,7 +99,7 @@ function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ 
     const parsed = parse(fs.readFileSync(dotenvPath, { encoding }), { debug })
 
     Object.keys(parsed).forEach(function (key) {
-      if (!process.env.hasOwnProperty(key)) {
+      if (overwrite || !process.env.hasOwnProperty(key)) {
         process.env[key] = parsed[key]
       } else if (debug) {
         log(`"${key}" is already defined in \`process.env\` and will not be overwritten`)

--- a/tests/test-env-options.js
+++ b/tests/test-env-options.js
@@ -10,6 +10,7 @@ require('../lib/env-options')
 const e = process.env.DOTENV_CONFIG_ENCODING
 const p = process.env.DOTENV_CONFIG_PATH
 const d = process.env.DOTENV_CONFIG_DEBUG
+const o = process.env.DOTENV_CONFIG_OVERWRITE
 
 // get fresh object for each test
 function options () {
@@ -44,7 +45,11 @@ testOption('DOTENV_CONFIG_PATH', '~/.env.test', { path: '~/.env.test' })
 // sets debug option
 testOption('DOTENV_CONFIG_DEBUG', 'true', { debug: 'true' })
 
+// sets debug option
+testOption('DOTENV_CONFIG_OVERWRITE', 'true', { overwrite: 'true' })
+
 // restore existing env
 process.env.DOTENV_CONFIG_ENCODING = e
 process.env.DOTENV_CONFIG_PATH = p
 process.env.DOTENV_CONFIG_DEBUG = d
+process.env.DOTENV_CONFIG_OVERWRITE = o


### PR DESCRIPTION
Support passing a `--overwrite` flag to enable overwriting existing environment variables.

This is useful for obvious reasons, and really is preferable to running `export KEY=` for each and every environment variable.