### PR TITLE
Add parse value type feature

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -60,7 +60,7 @@ function parse (src /*: string | Buffer */, options /*: ?DotenvParseOptions */) 
         }
       } else {
         // remove surrounding whitespace
-        val = val.trim()
+        val = parseValueType(val.trim())
       }
 
       obj[key] = val
@@ -106,6 +106,19 @@ function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ 
   } catch (e) {
     return { error: e }
   }
+}
+
+// Parse value into the correct type
+function parseValueType (value) {
+  if (value.toLowerCase() === 'true' || value.toLowerCase() === 'false') {
+    return value.toLowerCase() === 'true'
+  }
+
+  if (!isNaN(value)) {
+    return parseFloat(value)
+  }
+
+  return value
 }
 
 module.exports.config = config

--- a/tests/.env
+++ b/tests/.env
@@ -3,6 +3,8 @@ BASIC=basic
 # previous line intentionally left blank
 AFTER_LINE=after_line
 EMPTY=
+TYPE_BOOLEAN=true
+TYPE_NUMBER=123
 SINGLE_QUOTES='single_quotes'
 SINGLE_QUOTES_SPACED='    single quotes    '
 DOUBLE_QUOTES="double_quotes"

--- a/tests/test-parse.js
+++ b/tests/test-parse.js
@@ -55,6 +55,10 @@ t.equal(parsed.USERNAME, 'therealnerdybeast@example.tld', 'parses email addresse
 
 t.equal(parsed.SPACED_KEY, 'parsed', 'parses keys and values surrounded by spaces')
 
+t.equal(parsed.TYPE_BOOLEAN, true, 'test type of boolean')
+
+t.equal(parsed.TYPE_NUMBER, 123, 'test type of number')
+
 const payload = dotenv.parse(Buffer.from('BUFFER=true'))
 t.equal(payload.BUFFER, 'true', 'should parse a buffer into an object')
 


### PR DESCRIPTION
When parse an .env file into an object, parses values like `true`  or `false` or `123` into the correct type.
The way it is now, all values is parsed as strings.