### PR TITLE
Add option for multiple configurations based on NODE_ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,21 @@ You may specify a custom path if your file containing environment variables is l
 require('dotenv').config({ path: '/full/custom/path/to/your/env/vars' })
 ```
 
+#### MultiConfig
+
+Default: `path.resolve(process.cwd(), '.env')`
+
+Instead of loading `.env` or a custom path, load a configuration file with a suffix matching `NODE_ENV`.
+
+For example, if `NODE_ENV=production` then dotenv will look for `.env.production`.
+If `NODE_ENV=development` then dotenv will look for `.env.development`
+
+If using a custom path, this option will search for that path suffixed with `NODE_ENV`.
+
+```js
+require('dotenv').config({ multiConfig: true })
+```
+
 #### Encoding
 
 Default: `utf8`

--- a/lib/cli-options.js
+++ b/lib/cli-options.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-const re = /^dotenv_config_(encoding|path|debug)=(.+)$/
+const re = /^dotenv_config_(debug|encoding|multiConfig|path)=(.+)$/
 
 module.exports = function optionMatcher (args /*: Array<string> */) {
   return args.reduce(function (acc, cur) {

--- a/lib/env-options.js
+++ b/lib/env-options.js
@@ -15,4 +15,8 @@ if (process.env.DOTENV_CONFIG_DEBUG != null) {
   options.debug = process.env.DOTENV_CONFIG_DEBUG
 }
 
+if (process.env.DOTENV_CONFIG_MULTICONFIG != null) {
+  options.multiConfig = process.env.DOTENV_CONFIG_MULTICONFIG
+}
+
 module.exports = options

--- a/lib/main.js
+++ b/lib/main.js
@@ -92,7 +92,14 @@ function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ 
     // Make sure to process this argument after options.path
     // This way we can resolve multiple configurations at any given path.
     if (options.multiConfig != null) {
-      dotenvPath = `${dotenvPath}.${process.env.NODE_ENV}`
+      // Some engines will set an undefined process.env.NODE_ENV as
+      // the string literal 'undefined'
+      if (!(
+        process.env.NODE_ENV === undefined ||
+        process.env.NODE_ENV === 'undefined'
+      )) {
+        dotenvPath = `${dotenvPath}.${process.env.NODE_ENV}`
+      }
     }
   }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -9,9 +9,10 @@ type DotenvParseOptions = {
 type DotenvParseOutput = { [string]: string }
 
 type DotenvConfigOptions = {
-  path?: string, // path to .env file
-  encoding?: string, // encoding of .env file
   debug?: string // turn on logging for debugging purposes
+  encoding?: string, // encoding of .env file
+  multiConfig?: boolean, // load configuration based on NODE_ENV
+  path?: string, // path to .env file
 }
 
 type DotenvConfigOutput = {
@@ -87,6 +88,11 @@ function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ 
     }
     if (options.debug != null) {
       debug = true
+    }
+    // Make sure to process this argument after options.path
+    // This way we can resolve multiple configurations at any given path.
+    if (options.multiConfig != null) {
+      dotenvPath = `${dotenvPath}.${process.env.NODE_ENV}`
     }
   }
 

--- a/tests/test-cli-options.js
+++ b/tests/test-cli-options.js
@@ -4,7 +4,7 @@ const t = require('tap')
 
 const options = require('../lib/cli-options')
 
-t.plan(5)
+t.plan(6)
 
 // matches encoding option
 t.same(options(['node', '-e', "'console.log(testing)'", 'dotenv_config_encoding=utf8']), {
@@ -19,6 +19,11 @@ t.same(options(['node', '-e', "'console.log(testing)'", 'dotenv_config_path=/cus
 // matches debug option
 t.same(options(['node', '-e', "'console.log(testing)'", 'dotenv_config_debug=true']), {
   debug: 'true'
+})
+
+// matches multiConfig option
+t.same(options(['node', '-e', "'console.log(testing)'", 'dotenv_config_multiConfig=true']), {
+  multiConfig: 'true'
 })
 
 // ignores empty values

--- a/tests/test-config.js
+++ b/tests/test-config.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 const fs = require('fs')
+const path = require('path')
 
 const sinon = require('sinon')
 const t = require('tap')
@@ -11,7 +12,7 @@ const mockParseResponse = { test: 'foo' }
 let readFileSyncStub
 let parseStub
 
-t.plan(8)
+t.plan(9)
 
 t.beforeEach(done => {
   readFileSyncStub = sinon.stub(fs, 'readFileSync').returns('test=foo')
@@ -51,6 +52,16 @@ t.test('takes option for debug', ct => {
 
   ct.ok(logStub.called)
   logStub.restore()
+})
+
+t.test('takes option for multiConfig', ct => {
+  ct.plan(1)
+
+  dotenv.config({ multiConfig: true })
+  ct.equal(
+    readFileSyncStub.args[0][0],
+    `${path.resolve(process.cwd(), '.env')}.${process.env.NODE_ENV}`
+  )
 })
 
 t.test('reads path with encoding, parsing output to process.env', ct => {

--- a/tests/test-env-options.js
+++ b/tests/test-env-options.js
@@ -7,9 +7,10 @@ const decache = require('decache')
 require('../lib/env-options')
 
 // preserve existing env
-const e = process.env.DOTENV_CONFIG_ENCODING
-const p = process.env.DOTENV_CONFIG_PATH
 const d = process.env.DOTENV_CONFIG_DEBUG
+const e = process.env.DOTENV_CONFIG_ENCODING
+const m = process.env.DOTENV_CONFIG_MULTICONFIG
+const p = process.env.DOTENV_CONFIG_PATH
 
 // get fresh object for each test
 function options () {
@@ -26,12 +27,13 @@ function testOption (envVar, tmpVal, expect) {
   delete process.env[envVar]
 }
 
-t.plan(4)
+t.plan(5)
 
 // returns empty object when no options set in process.env
-delete process.env.DOTENV_CONFIG_ENCODING
-delete process.env.DOTENV_CONFIG_PATH
 delete process.env.DOTENV_CONFIG_DEBUG
+delete process.env.DOTENV_CONFIG_ENCODING
+delete process.env.DOTENV_CONFIG_MULTICONFIG
+delete process.env.DOTENV_CONFIG_PATH
 
 t.same(options(), {})
 
@@ -44,7 +46,11 @@ testOption('DOTENV_CONFIG_PATH', '~/.env.test', { path: '~/.env.test' })
 // sets debug option
 testOption('DOTENV_CONFIG_DEBUG', 'true', { debug: 'true' })
 
+// sets multiConfig option
+testOption('DOTENV_CONFIG_MULTICONFIG', 'true', { multiConfig: 'true' })
+
 // restore existing env
-process.env.DOTENV_CONFIG_ENCODING = e
-process.env.DOTENV_CONFIG_PATH = p
 process.env.DOTENV_CONFIG_DEBUG = d
+process.env.DOTENV_CONFIG_ENCODING = e
+process.env.DOTENV_CONFIG_MULTICONFIG = m
+process.env.DOTENV_CONFIG_PATH = p


### PR DESCRIPTION
With this option, dotenv can use multiple configurations by searching for `` `.env.${process.env.NODE_ENV}` ``.

This means instead of a single `.env` file, we can use `.env.production`, `.env.development`, etc.

It also works with custom paths.