### PR TITLE
Ignore coverage folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
-# Coverage directory
+# Coverage directories
 .nyc_output
+coverage
 
 # Dependency directory
 node_modules
 
 .DS_Store
+


### PR DESCRIPTION
https://github.com/motdotla/dotenv/pull/394 creates a directory named `coverage` in the project root.

This PR makes sure the folder is ignored.