### PR TITLE
Ignore empty lines

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -39,6 +39,7 @@ function parse (src /*: string | Buffer */, options /*: ?DotenvParseOptions */) 
 
   // convert Buffers before splitting into lines and processing
   src.toString().split(NEWLINE).forEach(function (line, idx) {
+    if (line.trim() === '') return; //ignore empty lines
     // matching "KEY' and 'VAL' in 'KEY=VAL'
     const keyValueArr = line.match(RE_INI_KEY_VAL)
     // matched?


### PR DESCRIPTION
In debug mode, show errors like:
```[dotenv][DEBUG] did not match key and value when parsing line <n>:```
Sometimes we need to add empty lines to separate groups of variables.
We don't want the debugger catch them.
