### PR TITLE
Allow export in dotenv files

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ The parsing engine currently supports the following rules:
 {MULTILINE: 'new
 line'}
 ```
+- lines beginning with `export` are parsed normally
 
 ## FAQ
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -29,7 +29,7 @@ function log (message /*: string */) {
 }
 
 const NEWLINE = '\n'
-const RE_INI_KEY_VAL = /^\s*([\w.-]+)\s*=\s*(.*)?\s*$/
+const RE_INI_KEY_VAL = /^\s*(?:export\s+)?([\w.-]+)\s*=\s*(.*)?\s*$/
 const RE_NEWLINES = /\\n/g
 
 // Parses src into an Object

--- a/tests/.env
+++ b/tests/.env
@@ -21,3 +21,8 @@ RETAIN_INNER_QUOTES_AS_STRING='{"foo": "bar"}'
 TRIM_SPACE_FROM_UNQUOTED=    some spaced out string
 USERNAME=therealnerdybeast@example.tld
     SPACED_KEY = parsed
+# export support
+export DESPITE_EXPORT=parsed
+EXPORT=exported1                                                                                                                                                                                                                                                                                               
+export=exported2
+exported=exported3

--- a/tests/test-parse.js
+++ b/tests/test-parse.js
@@ -9,7 +9,7 @@ const dotenv = require('../lib/main')
 
 const parsed = dotenv.parse(fs.readFileSync('tests/.env', { encoding: 'utf8' }))
 
-t.plan(24)
+t.plan(28)
 
 t.type(parsed, Object, 'should return an object')
 
@@ -54,6 +54,13 @@ t.equal(parsed.TRIM_SPACE_FROM_UNQUOTED, 'some spaced out string', 'retains spac
 t.equal(parsed.USERNAME, 'therealnerdybeast@example.tld', 'parses email addresses completely')
 
 t.equal(parsed.SPACED_KEY, 'parsed', 'parses keys and values surrounded by spaces')
+
+t.equal(parsed.DESPITE_EXPORT, 'parsed', 'parses despite leading export')
+
+t.equal(parsed.EXPORT, 'exported1', 'parses EXPORT as a variable name if no export prefix')
+t.equal(parsed.export, 'exported2', 'parses export as a variable name if no export prefix')
+
+t.equal(parsed.exported, 'exported3', 'is not confused by variables starting with export')
 
 const payload = dotenv.parse(Buffer.from('BUFFER=true'))
 t.equal(payload.BUFFER, 'true', 'should parse a buffer into an object')


### PR DESCRIPTION
These are simple changes that allow leading export in dotenv environment variables.
Continues #118.
Should bring this dotenv repo in line with all the other implementations.