### PR TITLE
Parse \r line endings (mac)

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -38,10 +38,8 @@ function parse (src /*: string | Buffer */, options /*: ?DotenvParseOptions */) 
   const debug = Boolean(options && options.debug)
   const obj = {}
 
-  // convert src to string and replace all EOLs to standard unix EOL
-  src = (Buffer.isBuffer(src) ? src.toString() : src).replace(NEWLINES_MATCH, NEWLINE)
-
-  src.split(NEWLINE).forEach(function (line, idx) {
+  // convert Buffers before splitting into lines and processing
+  src.toString().split(NEWLINES_MATCH).forEach(function (line, idx) {
     // matching "KEY' and 'VAL' in 'KEY=VAL'
     const keyValueArr = line.match(RE_INI_KEY_VAL)
     // matched?

--- a/lib/main.js
+++ b/lib/main.js
@@ -31,14 +31,17 @@ function log (message /*: string */) {
 const NEWLINE = '\n'
 const RE_INI_KEY_VAL = /^\s*([\w.-]+)\s*=\s*(.*)?\s*$/
 const RE_NEWLINES = /\\n/g
+const NEWLINES_MATCH = /\n|\r|\r\n/
 
 // Parses src into an Object
 function parse (src /*: string | Buffer */, options /*: ?DotenvParseOptions */) /*: DotenvParseOutput */ {
   const debug = Boolean(options && options.debug)
   const obj = {}
 
-  // convert Buffers before splitting into lines and processing
-  src.toString().split(NEWLINE).forEach(function (line, idx) {
+  // convert src to string and replace all EOLs to standard unix EOL
+  src = (Buffer.isBuffer(src) ? src.toString() : src).replace(NEWLINES_MATCH, NEWLINE)
+
+  src.split(NEWLINE).forEach(function (line, idx) {
     // matching "KEY' and 'VAL' in 'KEY=VAL'
     const keyValueArr = line.match(RE_INI_KEY_VAL)
     // matched?

--- a/tests/test-parse.js
+++ b/tests/test-parse.js
@@ -63,10 +63,10 @@ const expectedPayload = { SERVER: 'localhost', PASSWORD: 'password', DB: 'tests'
 const RPayload = dotenv.parse(Buffer.from('SERVER=localhost\rPASSWORD=password\rDB=tests\r'))
 t.same(RPayload, expectedPayload, 'can parse (\\r) line endings')
 
-const NPayload = dotenv.parse(Buffer.from('SERVER=localhost\rPASSWORD=password\rDB=tests\r'))
+const NPayload = dotenv.parse(Buffer.from('SERVER=localhost\nPASSWORD=password\nDB=tests\n'))
 t.same(NPayload, expectedPayload, 'can parse (\\n) line endings')
 
-const RNPayload = dotenv.parse(Buffer.from('SERVER=localhost\rPASSWORD=password\rDB=tests\r'))
+const RNPayload = dotenv.parse(Buffer.from('SERVER=localhost\r\nPASSWORD=password\r\nDB=tests\r\n'))
 t.same(RNPayload, expectedPayload, 'can parse (\\r\\n) line endings')
 
 // test debug path

--- a/tests/test-parse.js
+++ b/tests/test-parse.js
@@ -9,7 +9,7 @@ const dotenv = require('../lib/main')
 
 const parsed = dotenv.parse(fs.readFileSync('tests/.env', { encoding: 'utf8' }))
 
-t.plan(24)
+t.plan(27)
 
 t.type(parsed, Object, 'should return an object')
 
@@ -58,8 +58,16 @@ t.equal(parsed.SPACED_KEY, 'parsed', 'parses keys and values surrounded by space
 const payload = dotenv.parse(Buffer.from('BUFFER=true'))
 t.equal(payload.BUFFER, 'true', 'should parse a buffer into an object')
 
-const macPayload = dotenv.parse(Buffer.from('MAC=true\rEOL=true'))
-t.same(macPayload, { MAC: 'true', EOL: 'true' }, 'can parse mac (\\r) line endings')
+const expectedPayload = { SERVER: 'localhost', PASSWORD: 'password', DB: 'tests' }
+
+const RPayload = dotenv.parse(Buffer.from('SERVER=localhost\rPASSWORD=password\rDB=tests\r'))
+t.same(RPayload, expectedPayload, 'can parse (\\r) line endings')
+
+const NPayload = dotenv.parse(Buffer.from('SERVER=localhost\rPASSWORD=password\rDB=tests\r'))
+t.same(NPayload, expectedPayload, 'can parse (\\n) line endings')
+
+const RNPayload = dotenv.parse(Buffer.from('SERVER=localhost\rPASSWORD=password\rDB=tests\r'))
+t.same(RNPayload, expectedPayload, 'can parse (\\r\\n) line endings')
 
 // test debug path
 const logStub = sinon.stub(console, 'log')

--- a/tests/test-parse.js
+++ b/tests/test-parse.js
@@ -58,6 +58,9 @@ t.equal(parsed.SPACED_KEY, 'parsed', 'parses keys and values surrounded by space
 const payload = dotenv.parse(Buffer.from('BUFFER=true'))
 t.equal(payload.BUFFER, 'true', 'should parse a buffer into an object')
 
+const macPayload = dotenv.parse(Buffer.from('MAC=true\rEOL=true'))
+t.same(macPayload, { MAC: 'true', EOL: 'true' }, 'can parse mac (\\r) line endings')
+
 // test debug path
 const logStub = sinon.stub(console, 'log')
 dotenv.parse(Buffer.from('what is this'), { debug: true })


### PR DESCRIPTION
Fixes #409 by finding all three EOL types (\n, \r, \r\n) and replacing it with the NEWLINE variable, currently being the Unix standard.

When i run `npm test` i get back `Error: test count exceeds plan`.

I have not used TAP to write tests before but i assume i need a plan to run the tests locally. However if i deliberately break the test it shows a different error, so im assuming the test works.

@maxbeatty 