### PR TITLE
Added feature to enable watching of the configuration file and update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 node_modules
 
 .DS_Store
+
+# Jetbrains config
+.idea

--- a/lib/main.js
+++ b/lib/main.js
@@ -77,6 +77,7 @@ function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ 
   let dotenvPath = path.resolve(process.cwd(), '.env')
   let encoding /*: string */ = 'utf8'
   let debug = false
+  let watch = false
 
   if (options) {
     if (options.path != null) {
@@ -88,25 +89,48 @@ function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ 
     if (options.debug != null) {
       debug = true
     }
+    if (options.watch != null) {
+      watch = true
+    }
   }
 
-  try {
-    // specifying an encoding returns a string instead of a buffer
-    const parsed = parse(fs.readFileSync(dotenvPath, { encoding }), { debug })
+  // Putting the logic that assigns the config values in a function so that is will be reusable
+  // Replace parameter is to specify whether or not to replace the config values since the initial
+  // logic does not replace initial config values
+  let updateConfigFn = function (replace) {
+    try {
+      // specifying an encoding returns a string instead of a buffer
+      const parsed = parse(fs.readFileSync(dotenvPath, { encoding }), { debug })
 
-    Object.keys(parsed).forEach(function (key) {
-      if (!process.env.hasOwnProperty(key)) {
-        process.env[key] = parsed[key]
-      } else if (debug) {
-        log(`"${key}" is already defined in \`process.env\` and will not be overwritten`)
+      Object.keys(parsed).forEach(function (key) {
+        if ((!replace && !process.env.hasOwnProperty(key)) || (replace && process.env[key] !== parsed[key])) {
+          process.env[key] = parsed[key]
+        } else if (debug) {
+          log(`"${key}" is already defined in \`process.env\` and will not be overwritten`)
+        }
+      })
+
+      return { parsed }
+    } catch (e) {
+      return { error: e }
+    }
+  }
+
+  if (watch) {
+    fs.watchFile(dotenvPath, function (current, previous) {
+      // Check if modified time has changed hence if the file itself has been changed not just accessed
+      if (current.mtimeMs > previous.mtimeMs) {
+        updateConfigFn(true)
       }
     })
-
-    return { parsed }
-  } catch (e) {
-    return { error: e }
   }
+
+  return updateConfigFn(false)
 }
 
 module.exports.config = config
 module.exports.parse = parse
+
+// NB: Some of the tests failed because I didn't know how to write the tests for this specific feature that I added,
+// This feature is based on my experience using this library and the fact that sometimes configurations change
+// and for the update to happen the app has to be started which is sometimes not ideal for some specific situations


### PR DESCRIPTION
Auto-update of any configuration that has changed real-time without the need to restart app; unable to write tests for this particular feature though hence some tests failed. This watch will be activated upon request by configuration supply in config function as in some situations the app restart is required to successfully and smoothly apply the new configuration changes.