### PR TITLE
Added jsdocs for intellisense

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -18,8 +18,17 @@ type DotenvConfigOutput = {
   parsed?: DotenvParseOutput,
   error?: Error
 }
-
 */
+
+/**
+ * @typedef {Object} DotenvConfigOptions
+ * @property {String} [path] - Custom path to config file
+ * @property {"utf8" | "ascii" | "base64" | "binary" | "hex" | "ucs2" | "latin1"} [encoding] - Encoding to interpret file with. Default utf8
+ * @property {Boolean} [debug] - Turn on logging when setting keys and values
+ *
+ * @typedef {Object} DotenvParseOptions
+ * @property {Boolean} [debug] - Turn on logging when setting keys and values
+ */
 
 const fs = require('fs')
 const path = require('path')
@@ -33,7 +42,12 @@ const RE_INI_KEY_VAL = /^\s*([\w.-]+)\s*=\s*(.*)?\s*$/
 const RE_NEWLINES = /\\n/g
 const NEWLINES_MATCH = /\n|\r|\r\n/
 
-// Parses src into an Object
+/**
+ * Parses src into an Object
+ * @param {String | ArrayBuffer} src - String to be parsed into an object
+ * @param {DotenvParseOptions} options - Options for parsing the file
+ * @returns {Object} Parsed object
+ */
 function parse (src /*: string | Buffer */, options /*: ?DotenvParseOptions */) /*: DotenvParseOutput */ {
   const debug = Boolean(options && options.debug)
   const obj = {}
@@ -73,7 +87,11 @@ function parse (src /*: string | Buffer */, options /*: ?DotenvParseOptions */) 
   return obj
 }
 
-// Populates process.env from .env file
+/**
+ * Populates process.env from .env file
+ * @param {DotenvConfigOptions} options - Options for config
+ * @returns {Object} Parsed object
+ */
 function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ {
   let dotenvPath = path.resolve(process.cwd(), '.env')
   let encoding /*: string */ = 'utf8'


### PR DESCRIPTION
I added some basic jsdoc for the parse and config methods. This will add some neat intellisense for VS Code and possible other IDEs that support jsdoc.

![image](https://user-images.githubusercontent.com/34691326/63256749-841f0400-c278-11e9-9e51-c6d503b46674.png)
![image](https://user-images.githubusercontent.com/34691326/63256699-681b6280-c278-11e9-8173-9f71a049b461.png)

I am not certain that the descriptions are the best, so any suggestions for better descriptions would be great.