### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/motdotla/dotenv.git"
+    "url": "https://github.com/motdotla/dotenv"
   },
+  "bugs": {
+    "url": "https://github.com/motdotla/dotenv/issues"
+  },
+  "author": "Scott Motte <mot@mot.la> (http://mot.la)",
   "keywords": [
     "dotenv",
     "env",


### PR DESCRIPTION
I wanted to bring this in line with the changes I made in motdotla/dotenv-expand#27

> I went to the [`npm` page of this package](https://www.npmjs.com/package/dotenv-expand) and wanted to link back to the repo itself, but there wasn't any link available.
> Updating these fields will help with that.