### PR TITLE
DotenvConfigOptions: new parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,16 @@ You may turn on logging to help debug why certain keys or values are not being s
 require('dotenv').config({ debug: process.env.DEBUG })
 ```
 
+#### Overwrite
+
+Default: `false`
+
+You may turn on overwriting already defined environment variables from `.env` to set up values more specific to your project.
+
+```js
+require('dotenv').config({ overwrite: true })
+```
+
 ## Parse
 
 The engine which parses the contents of your file containing environment

--- a/lib/main.js
+++ b/lib/main.js
@@ -11,7 +11,8 @@ type DotenvParseOutput = { [string]: string }
 type DotenvConfigOptions = {
   path?: string, // path to .env file
   encoding?: string, // encoding of .env file
-  debug?: string // turn on logging for debugging purposes
+  debug?: string, // turn on logging for debugging purposes
+  overwrite?: boolean // turn on existing envs overwrite
 }
 
 type DotenvConfigOutput = {
@@ -78,6 +79,7 @@ function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ 
   let dotenvPath = path.resolve(process.cwd(), '.env')
   let encoding /*: string */ = 'utf8'
   let debug = false
+  let overwrite = false
 
   if (options) {
     if (options.path != null) {
@@ -89,6 +91,9 @@ function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ 
     if (options.debug != null) {
       debug = true
     }
+    if (options.overwrite != null) {
+      overwrite = true
+    }
   }
 
   try {
@@ -96,7 +101,8 @@ function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ 
     const parsed = parse(fs.readFileSync(dotenvPath, { encoding }), { debug })
 
     Object.keys(parsed).forEach(function (key) {
-      if (!Object.prototype.hasOwnProperty.call(process.env, key)) {
+      const alreadyHasKey = Object.prototype.hasOwnProperty.call(process.env, key)
+      if (!alreadyHasKey || overwrite) {
         process.env[key] = parsed[key]
       } else if (debug) {
         log(`"${key}" is already defined in \`process.env\` and will not be overwritten`)


### PR DESCRIPTION
Added optional `overwrite` parameter to override upper-level-defined environmental variables with values from `.env`