### PR TITLE
change resolved path to be absolute to the current project activate d…

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -75,7 +75,7 @@ function parse (src /*: string | Buffer */, options /*: ?DotenvParseOptions */) 
 
 // Populates process.env from .env file
 function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ {
-  let dotenvPath = path.resolve(process.cwd(), '.env')
+  let dotenvPath = path.resolve(__dirname, '.env')
   let encoding /*: string */ = 'utf8'
   let debug = false
 


### PR DESCRIPTION
If you activate your project using dotenv from different location for example you are running your node project as a global cli then `dotenv` won't load configs properly since its using process.cwd() as the resolved path: https://github.com/motdotla/dotenv/blob/70425a9c88e5fe5c3bd128fa973701279a76a9e3/lib/main.js#L78

changing it to `__dirname` make it absolute to the project root thus working from everywhere