### PR TITLE
Safe with defaults

### DIFF
--- a/lib/cli-options.js
+++ b/lib/cli-options.js
@@ -1,12 +1,21 @@
 /* @flow */
 
-const re = /^dotenv_config_(encoding|path|debug)=(.+)$/
+const re = /^dotenv_config_(encoding|path|debug|example_path|default_path|extended)=(.+)$/
+
+const map = {
+  encoding: 'encoding',
+  path: 'path',
+  debug: 'debug',
+  example_path: 'examplePath',
+  default_path: 'defaultPath',
+  extended: 'extended'
+}
 
 module.exports = function optionMatcher (args /*: Array<string> */) {
   return args.reduce(function (acc, cur) {
     const matches = cur.match(re)
     if (matches) {
-      acc[matches[1]] = matches[2]
+      acc[map[matches[1]]] = matches[2]
     }
     return acc
   }, {})

--- a/lib/env-options.js
+++ b/lib/env-options.js
@@ -15,4 +15,16 @@ if (process.env.DOTENV_CONFIG_DEBUG != null) {
   options.debug = process.env.DOTENV_CONFIG_DEBUG
 }
 
+if (process.env.DOTENV_CONFIG_EXAMPLE_PATH != null) {
+  options.examplePath = process.env.DOTENV_CONFIG_EXAMPLE_PATH
+}
+
+if (process.env.DOTENV_CONFIG_DEFAULT_PATH != null) {
+  options.defaultPath = process.env.DOTENV_CONFIG_DEFAULT_PATH
+}
+
+if (process.env.DOTENV_CONFIG_EXTENDED != null) {
+  options.extended = process.env.DOTENV_CONFIG_EXTENDED
+}
+
 module.exports = options

--- a/lib/main.js
+++ b/lib/main.js
@@ -10,8 +10,11 @@ type DotenvParseOutput = { [string]: string }
 
 type DotenvConfigOptions = {
   path?: string, // path to .env file
+  examplePath?: string,
+  defaultPath?: string,
   encoding?: string, // encoding of .env file
-  debug?: string // turn on logging for debugging purposes
+  debug?: string, // turn on logging for debugging purposes
+  extended?: string
 }
 
 type DotenvConfigOutput = {
@@ -23,6 +26,7 @@ type DotenvConfigOutput = {
 
 const fs = require('fs')
 const path = require('path')
+const { covers } = require('./utils')
 
 function log (message /*: string */) {
   console.log(`[dotenv][DEBUG] ${message}`)
@@ -92,12 +96,21 @@ function populateEnv (parsed /*: DotenvParseOutput */, debug /*: boolean */) {
 // Populates process.env from .env file
 function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ {
   let dotenvPath = path.resolve(process.cwd(), '.env')
+  let examplePath = path.resolve(process.cwd(), '.env.example')
+  let defaultPath = path.resolve(process.cwd(), '.env.default')
   let encoding /*: string */ = 'utf8'
   let debug = false
+  let extended = false
 
   if (options) {
     if (options.path != null) {
       dotenvPath = options.path
+    }
+    if (options.examplePath != null) {
+      examplePath = options.examplePath
+    }
+    if (options.defaultPath != null) {
+      defaultPath = options.defaultPath
     }
     if (options.encoding != null) {
       encoding = options.encoding
@@ -105,10 +118,23 @@ function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ 
     if (options.debug != null) {
       debug = true
     }
+    if (options.extended != null) {
+      extended = true
+    }
   }
 
   try {
-    const parsed = readAndParse(dotenvPath, encoding, debug)
+    let parsed = readAndParse(dotenvPath, encoding, debug)
+
+    if (extended) {
+      const exampleEnv = readAndParse(examplePath, encoding, debug)
+      const defaultEnv = readAndParse(defaultPath, encoding, debug)
+      parsed = Object.assign({}, defaultEnv, parsed)
+
+      if (!covers(parsed, exampleEnv)) {
+        throw new Error('Missing variables!')
+      }
+    }
 
     populateEnv(parsed, debug)
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -73,6 +73,22 @@ function parse (src /*: string | Buffer */, options /*: ?DotenvParseOptions */) 
   return obj
 }
 
+// Reads a config file and returns a config Object
+function readAndParse (dotenvPath /*: string */, encoding /*: string */, debug /*: boolean */) /*: DotenvParseOutput */ {
+  return parse(fs.readFileSync(dotenvPath, { encoding }), { debug })
+}
+
+// Populates process.env from a config Object
+function populateEnv (parsed /*: DotenvParseOutput */, debug /*: boolean */) {
+  Object.keys(parsed).forEach(function (key) {
+    if (!Object.prototype.hasOwnProperty.call(process.env, key)) {
+      process.env[key] = parsed[key]
+    } else if (debug) {
+      log(`"${key}" is already defined in \`process.env\` and will not be overwritten`)
+    }
+  })
+}
+
 // Populates process.env from .env file
 function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ {
   let dotenvPath = path.resolve(process.cwd(), '.env')
@@ -92,16 +108,9 @@ function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ 
   }
 
   try {
-    // specifying an encoding returns a string instead of a buffer
-    const parsed = parse(fs.readFileSync(dotenvPath, { encoding }), { debug })
+    const parsed = readAndParse(dotenvPath, encoding, debug)
 
-    Object.keys(parsed).forEach(function (key) {
-      if (!Object.prototype.hasOwnProperty.call(process.env, key)) {
-        process.env[key] = parsed[key]
-      } else if (debug) {
-        log(`"${key}" is already defined in \`process.env\` and will not be overwritten`)
-      }
-    })
+    populateEnv(parsed, debug)
 
     return { parsed }
   } catch (e) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,9 @@
+/* @flow */
+
+function covers /*:: <T> */(big /*: {[string]: T} */, small /*: {[string]: T} */) /*: boolean */ {
+  return Object.keys(small).every(key => Object.prototype.hasOwnProperty.call(big, key))
+}
+
+module.exports = {
+  covers
+}

--- a/tests/.env.example
+++ b/tests/.env.example
@@ -1,0 +1,2 @@
+BASIC=basic
+NOT_PROVIDED=

--- a/tests/test-cli-options.js
+++ b/tests/test-cli-options.js
@@ -4,7 +4,7 @@ const t = require('tap')
 
 const options = require('../lib/cli-options')
 
-t.plan(5)
+t.plan(8)
 
 // matches encoding option
 t.same(options(['node', '-e', "'console.log(testing)'", 'dotenv_config_encoding=utf8']), {
@@ -19,6 +19,21 @@ t.same(options(['node', '-e', "'console.log(testing)'", 'dotenv_config_path=/cus
 // matches debug option
 t.same(options(['node', '-e', "'console.log(testing)'", 'dotenv_config_debug=true']), {
   debug: 'true'
+})
+
+// matches example path option
+t.same(options(['node', '-e', "'console.log(testing)'", 'dotenv_config_example_path=/path/to/.env.example']), {
+  examplePath: '/path/to/.env.example'
+})
+
+// matches default path option
+t.same(options(['node', '-e', "'console.log(testing)'", 'dotenv_config_default_path=/path/to/.env.default']), {
+  defaultPath: '/path/to/.env.default'
+})
+
+// matches extended option
+t.same(options(['node', '-e', "'console.log(testing)'", 'dotenv_config_extended=true']), {
+  extended: 'true'
 })
 
 // ignores empty values

--- a/tests/test-env-options.js
+++ b/tests/test-env-options.js
@@ -10,6 +10,9 @@ require('../lib/env-options')
 const e = process.env.DOTENV_CONFIG_ENCODING
 const p = process.env.DOTENV_CONFIG_PATH
 const d = process.env.DOTENV_CONFIG_DEBUG
+const ep = process.env.DOTENV_CONFIG_EXAMPLE_PATH
+const dp = process.env.DOTENV_CONFIG_DEFAULT_PATH
+const x = process.env.DOTENV_CONFIG_EXTENDED
 
 // get fresh object for each test
 function options () {
@@ -26,12 +29,15 @@ function testOption (envVar, tmpVal, expect) {
   delete process.env[envVar]
 }
 
-t.plan(4)
+t.plan(7)
 
 // returns empty object when no options set in process.env
 delete process.env.DOTENV_CONFIG_ENCODING
 delete process.env.DOTENV_CONFIG_PATH
 delete process.env.DOTENV_CONFIG_DEBUG
+delete process.env.DOTENV_CONFIG_EXAMPLE_PATH
+delete process.env.DOTENV_CONFIG_DEFAULT_PATH
+delete process.env.DOTENV_CONFIG_EXTENDED
 
 t.same(options(), {})
 
@@ -44,7 +50,19 @@ testOption('DOTENV_CONFIG_PATH', '~/.env.test', { path: '~/.env.test' })
 // sets debug option
 testOption('DOTENV_CONFIG_DEBUG', 'true', { debug: 'true' })
 
+// sets example path option
+testOption('DOTENV_CONFIG_EXAMPLE_PATH', '~/.env.example', { examplePath: '~/.env.example' })
+
+// sets default path option
+testOption('DOTENV_CONFIG_DEFAULT_PATH', '~/.env.default', { defaultPath: '~/.env.default' })
+
+// sets extended option
+testOption('DOTENV_CONFIG_EXTENDED', 'true', { extended: 'true' })
+
 // restore existing env
 process.env.DOTENV_CONFIG_ENCODING = e
 process.env.DOTENV_CONFIG_PATH = p
 process.env.DOTENV_CONFIG_DEBUG = d
+process.env.DOTENV_CONFIG_EXAMPLE_PATH = ep
+process.env.DOTENV_CONFIG_DEFAULT_PATH = dp
+process.env.DOTENV_CONFIG_EXTENDED = x

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -1,0 +1,18 @@
+const t = require('tap')
+const { covers } = require('../lib/utils')
+
+t.equal(covers({}, {}), true, 'empty object should cover empty object')
+
+t.equal(covers({ foo: null }, {}), true, 'any object should cover empty object')
+
+t.equal(covers({}, { foo: null }), false, 'empty object should not cover anything other than empty object')
+
+t.equal(covers({ foo: null }, { foo: null }), true, 'an object should cover itself')
+
+t.equal(covers({ foo: null, bar: null }, { foo: null }), true, 'an object should cover another that has less keys')
+
+t.equal(covers({ foo: null }, { foo: null, bar: null }), false, 'an object should not cover another that has extra keys')
+
+t.equal(covers({ foo: null }, { bar: null }), false, 'an object should not cover another with different keys')
+
+t.equal(covers({ foo: null, bar: null }, { foo: null, baz: null }), false, 'an object should not cover another with different keys even if they share some keys')


### PR DESCRIPTION
In this PR I introduce handling of two extra files, `.env.default` and `.env.example`.

`.env.default` allows us to have default values. This should be used only for sane defaults, like the port number for a database. Usernames or passwords should never be put in there.

`.env.example` has two purposes: First, it allows the user to copy it as `.env` and modify it as a boilerplate. Second, it will throw if any of the variables is not provided. This accounts for defaults, `.env` and explicitly passed environment variables.

This behavior does not alter the existing functionality and it can be turned out by opting-in using the `extended` parameter. Default and example filenames can be overridden as well.

List of additional environment variables used:
- `DOTENV_CONFIG_EXAMPLE_PATH`
- `DOTENV_CONFIG_DEFAULT_PATH`
- `DOTENV_CONFIG_EXTENDED`

List of additional command line arguments:
- `dotenv_config_example_path`
- `dotenv_config_default_path`
- `dotenv_config_extended`

List of additional parameters to `config`:
- `examplePath`
- `defaultPath`
- `extended`

I have refactored the code a bit in the first commit to implement the features more easily. Everything introduced here is tested and 100% test coverage is maintained.

I'd really like for this to be merged and I can work on the potential issues. This is not complete but it's in a good state for reviews.

Once the API design is solidified, I can work on documenting the changes.