### PR TITLE
Add main interface for library

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -57,7 +57,7 @@ export interface DotenvConfigOutput {
 export function config(options?: DotenvConfigOptions): DotenvConfigOutput;
 
 /** dotenv library interface */
-export interface dotenv {
+export interface DotEnv {
   config: typeof config;
   parse: typeof parse;
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -55,5 +55,12 @@ export interface DotenvConfigOutput {
  *
  */
 export function config(options?: DotenvConfigOptions): DotenvConfigOutput;
+
+/** dotenv library interface */
+export interface dotenv {
+  config: typeof config;
+  parse: typeof parse;
+}
+
 /** @deprecated since v7.0.0 Use config instead. */
 export const load: typeof config;

--- a/types/test.ts
+++ b/types/test.ts
@@ -1,4 +1,9 @@
-import { config, parse } from "dotenv";
+import * as DotEnv from "dotenv";
+
+const { config, parse }: DotEnv.dotenv = {
+  config: DotEnv.config,
+  parse: DotEnv.parse
+};
 
 const env = config();
 const dbUrl: string | null =

--- a/types/test.ts
+++ b/types/test.ts
@@ -1,8 +1,8 @@
-import * as DotEnv from "dotenv";
+import * as dotenv from "dotenv";
 
-const { config, parse }: DotEnv.dotenv = {
-  config: DotEnv.config,
-  parse: DotEnv.parse
+const { config, parse }: dotenv.DotEnv = {
+  config: dotenv.config,
+  parse: dotenv.parse
 };
 
 const env = config();


### PR DESCRIPTION
As requested in the following Issue: #448 

The PR exports a main interface for the dotenv library.