### PR TITLE
fix: debug option

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -86,7 +86,7 @@ function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ 
     if (options.encoding != null) {
       encoding = options.encoding
     }
-    if (options.debug != null) {
+    if (options.debug) {
       debug = true
     }
   }


### PR DESCRIPTION
### When I configure the `debug` option to `false`, __it cannot run correctly__, and the type check can only be set to boolean or undefined,  which would be very unfriendly.