### PR TITLE
fix(package.json) : add the exact types file instead of the directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "8.2.0",
   "description": "Loads environment variables from .env file",
   "main": "lib/main.js",
-  "types": "types",
+  "types": "types/index.d.ts",
   "scripts": {
     "flow": "flow",
     "dtslint": "dtslint types",


### PR DESCRIPTION
This PR is here to solved the issue #475. This is an quick and easy fix at first proposed by @alexesprit.

This problem is actually pretty annoying when you are using VSCode. By pointing to `index.d.ts` directly we avoid the issue and it does not make any breaking change.

Again, pretty simple PR tho.

(First contribution ever, do not be afraid to tell me if anything is wrong !)