### PR TITLE
Allow for `import "dotenv/config";` in Node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "8.2.0",
   "description": "Loads environment variables from .env file",
   "main": "lib/main.js",
+  "exports": {
+    ".": "./lib/main.js",
+    "./config": "./config.js"
+  },
   "types": "types",
   "scripts": {
     "flow": "flow",

--- a/tests/test-config-cli.js
+++ b/tests/test-config-cli.js
@@ -29,7 +29,7 @@ t.plan(3)
 t.equal(
   spawn([
     '-r',
-    '../config',
+    './config',
     '-e',
     'console.log(process.env.BASIC)',
     'dotenv_config_encoding=utf8',
@@ -40,7 +40,7 @@ t.equal(
 
 // dotenv/config supports configuration via environment variables
 t.equal(
-  spawn(['-r', '../config', '-e', 'console.log(process.env.BASIC)'], {
+  spawn(['-r', './config', '-e', 'console.log(process.env.BASIC)'], {
     env: {
       DOTENV_CONFIG_PATH: './tests/.env'
     }
@@ -53,7 +53,7 @@ t.equal(
   spawn(
     [
       '-r',
-      '../config',
+      './config',
       '-e',
       'console.log(process.env.BASIC)',
       'dotenv_config_path=./tests/.env'


### PR DESCRIPTION
Currently the officially recommended method for auto-importing works with Babel-like configuration that automatically resolves `dotenv/config` to `dotenv/config.js`. However, Node.js doesn't do this resolution, and instead you have to manually specify the extension like this:

```js
// Babel OK, doesn't work on Node.js
import "dotenv/config";

// Works on Node.js (and Babel etc)
// See https://github.com/motdotla/dotenv/issues/89#issuecomment-587753552
import "dotenv/config.js";
```

A way of fixing this is by defining the export mapping in `package.json` as [explained in Node.js documentation](https://nodejs.org/api/packages.html#packages_package_entry_points):

```js
  "exports": {
    ".": "./lib/main.js",
    "./config": "./config.js"
  },
```