### PR TITLE
Adding a trim

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -39,7 +39,7 @@ function parse (src /*: string | Buffer */, options /*: ?DotenvParseOptions */) 
   const obj = {}
 
   // convert Buffers before splitting into lines and processing
-  src.toString().split(NEWLINES_MATCH).forEach(function (line, idx) {
+  src.toString().trim().split(NEWLINES_MATCH).forEach(function (line, idx) {
     // matching "KEY' and 'VAL' in 'KEY=VAL'
     const keyValueArr = line.match(RE_INI_KEY_VAL)
     // matched?


### PR DESCRIPTION
While using the lib I've noticed that the last empty line is also considered for key value decoding
adding a trim just to avoid this.