### PR TITLE
Feat: Scoped Env Vars

### DIFF
--- a/lib/cli-options.js
+++ b/lib/cli-options.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-const re = /^dotenv_config_(encoding|path|debug)=(.+)$/
+const re = /^dotenv_config_(encoding|path|debug|scoped)=(.+)$/
 
 module.exports = function optionMatcher (args /*: Array<string> */) {
   return args.reduce(function (acc, cur) {

--- a/lib/env-options.js
+++ b/lib/env-options.js
@@ -15,4 +15,8 @@ if (process.env.DOTENV_CONFIG_DEBUG != null) {
   options.debug = process.env.DOTENV_CONFIG_DEBUG
 }
 
+if (process.env.DOTENV_CONFIG_SCOPED != null) {
+  options.scoped = process.env.DOTENV_CONFIG_SCOPED
+}
+
 module.exports = options

--- a/lib/main.js
+++ b/lib/main.js
@@ -12,6 +12,7 @@ type DotenvConfigOptions = {
   path?: string, // path to .env file
   encoding?: string, // encoding of .env file
   debug?: string // turn on logging for debugging purposes
+  scoped?: boolean // do not assign values to 'process.env'
 }
 
 type DotenvConfigOutput = {
@@ -78,6 +79,7 @@ function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ 
   let dotenvPath = path.resolve(process.cwd(), '.env')
   let encoding /*: string */ = 'utf8'
   let debug = false
+  let scoped = false
 
   if (options) {
     if (options.path != null) {
@@ -89,19 +91,24 @@ function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ 
     if (options.debug != null) {
       debug = true
     }
+    if (options.scoped != null) {
+      scoped = true
+    }
   }
 
   try {
     // specifying an encoding returns a string instead of a buffer
     const parsed = parse(fs.readFileSync(dotenvPath, { encoding }), { debug })
 
-    Object.keys(parsed).forEach(function (key) {
-      if (!Object.prototype.hasOwnProperty.call(process.env, key)) {
-        process.env[key] = parsed[key]
-      } else if (debug) {
-        log(`"${key}" is already defined in \`process.env\` and will not be overwritten`)
-      }
-    })
+    if (!scoped) {
+      Object.keys(parsed).forEach(function (key) {
+        if (!Object.prototype.hasOwnProperty.call(process.env, key)) {
+          process.env[key] = parsed[key]
+        } else if (debug) {
+          log(`"${key}" is already defined in \`process.env\` and will not be overwritten`)
+        }
+      })
+    }
 
     return { parsed }
   } catch (e) {

--- a/tests/test-cli-options.js
+++ b/tests/test-cli-options.js
@@ -4,7 +4,7 @@ const t = require('tap')
 
 const options = require('../lib/cli-options')
 
-t.plan(5)
+t.plan(6)
 
 // matches encoding option
 t.same(options(['node', '-e', "'console.log(testing)'", 'dotenv_config_encoding=utf8']), {
@@ -19,6 +19,11 @@ t.same(options(['node', '-e', "'console.log(testing)'", 'dotenv_config_path=/cus
 // matches debug option
 t.same(options(['node', '-e', "'console.log(testing)'", 'dotenv_config_debug=true']), {
   debug: 'true'
+})
+
+// matches encapsulation option
+t.same(options(['node', '-e', "'console.log(testing)'", 'dotenv_config_scoped=true']), {
+  scoped: 'true'
 })
 
 // ignores empty values

--- a/tests/test-config-cli.js
+++ b/tests/test-config-cli.js
@@ -29,7 +29,7 @@ t.plan(3)
 t.equal(
   spawn([
     '-r',
-    '../config',
+    './config',
     '-e',
     'console.log(process.env.BASIC)',
     'dotenv_config_encoding=utf8',
@@ -40,7 +40,7 @@ t.equal(
 
 // dotenv/config supports configuration via environment variables
 t.equal(
-  spawn(['-r', '../config', '-e', 'console.log(process.env.BASIC)'], {
+  spawn(['-r', './config', '-e', 'console.log(process.env.BASIC)'], {
     env: {
       DOTENV_CONFIG_PATH: './tests/.env'
     }
@@ -53,7 +53,7 @@ t.equal(
   spawn(
     [
       '-r',
-      '../config',
+      './config',
       '-e',
       'console.log(process.env.BASIC)',
       'dotenv_config_path=./tests/.env'

--- a/tests/test-config.js
+++ b/tests/test-config.js
@@ -11,7 +11,7 @@ const mockParseResponse = { test: 'foo' }
 let readFileSyncStub
 let parseStub
 
-t.plan(8)
+t.plan(9)
 
 t.beforeEach(done => {
   readFileSyncStub = sinon.stub(fs, 'readFileSync').returns('test=foo')
@@ -51,6 +51,17 @@ t.test('takes option for debug', ct => {
 
   ct.ok(logStub.called)
   logStub.restore()
+})
+
+t.test('takes option for scoped', ct => {
+  ct.plan(2)
+
+  process.env.test && delete process.env.test
+
+  const scopedVars = dotenv.config({ scoped: true })
+
+  ct.equal(process.env.test, undefined, 'test should be undefined')
+  ct.equal(scopedVars.parsed.test, 'foo', 'test should be set to "foo"')
 })
 
 t.test('reads path with encoding, parsing output to process.env', ct => {

--- a/tests/test-env-options.js
+++ b/tests/test-env-options.js
@@ -10,6 +10,7 @@ require('../lib/env-options')
 const e = process.env.DOTENV_CONFIG_ENCODING
 const p = process.env.DOTENV_CONFIG_PATH
 const d = process.env.DOTENV_CONFIG_DEBUG
+const s = process.env.DOTENV_CONFIG_SCOPED
 
 // get fresh object for each test
 function options () {
@@ -26,12 +27,13 @@ function testOption (envVar, tmpVal, expect) {
   delete process.env[envVar]
 }
 
-t.plan(4)
+t.plan(5)
 
 // returns empty object when no options set in process.env
 delete process.env.DOTENV_CONFIG_ENCODING
 delete process.env.DOTENV_CONFIG_PATH
 delete process.env.DOTENV_CONFIG_DEBUG
+delete process.env.DOTENV_CONFIG_SCOPED
 
 t.same(options(), {})
 
@@ -44,7 +46,11 @@ testOption('DOTENV_CONFIG_PATH', '~/.env.test', { path: '~/.env.test' })
 // sets debug option
 testOption('DOTENV_CONFIG_DEBUG', 'true', { debug: 'true' })
 
+// sets scoped option
+testOption('DOTENV_CONFIG_SCOPED', 'true', { scoped: 'true' })
+
 // restore existing env
 process.env.DOTENV_CONFIG_ENCODING = e
 process.env.DOTENV_CONFIG_PATH = p
 process.env.DOTENV_CONFIG_DEBUG = d
+process.env.DOTENV_CONFIG_SCOPED = s


### PR DESCRIPTION
Currently, when a `.env` file is loaded the values are always assigned to `process.env`. This feature adds a `scoped` boolean option to skip the value assignments to `process.env`, and instead only return them in the `parsed` object.

My personal use case for this is wanting to keep the global scope of my project as clean as possible. In my project, I have multiple conenctions to databases and other services that can change randomly, and I didn't want to have unused or unnecessary secrets floating around globally. By keeping them in a local variable, we can let the gc get rid of them when we are done with them.

**All tests should pass on your machine.**