### PR TITLE
Fix small typo in JSDoc comment

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -47,7 +47,7 @@ export interface DotenvConfigOutput {
 }
 
 /**
- * Loads `.env` file contents into {@link https://nodejs.org/api/process.html#process_process_env | `process.env`}.
+ * Loads `.env` file contents into {@link https://nodejs.org/api/process.html#process_process_env `process.env`}.
  * Example: 'KEY=value' becomes { parsed: { KEY: 'value' } }
  *
  * @param options - controls behavior


### PR DESCRIPTION
This fixes a typo in the description of the config function where the `@link` had an extra | which is not needed.