### PR TITLE
Add package.json to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/main.js",
   "exports": {
     ".": "./lib/main.js",
-    "./config": "./config.js"
+    "./config": "./config.js",
+    "./package.json": "./package.json"
   },
   "types": "types/index.d.ts",
   "scripts": {


### PR DESCRIPTION
This is a fix for the error: `Package subpath './package.json' is not defined by "exports".`