### PR TITLE
Version bump 9.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [9.0.0](https://github.com/motdotla/dotenv/compare/v8.0.0...v9.0.0) (2021-05-05)
+
+### Added
+
+- define package.json in exports
+- allow for `import "dotenv/config"`
+
+### Changed
+
+- updated dev dependencies via npm audit
+- TypeScript types
+- point to exact types file to work with VS Code
+- _Breaking:_ drop support for Node v8
+
 ## [8.6.0](https://github.com/motdotla/dotenv/compare/v8.5.1...v8.6.0) (2021-05-05)
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dotenv",
-  "version": "8.6.0",
+  "version": "9.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dotenv",
-  "version": "8.6.0",
+  "version": "9.0.0",
   "description": "Loads environment variables from .env file",
   "main": "lib/main.js",
   "exports": {


### PR DESCRIPTION
The node version drop should have been a major semver bump. This PR rectifies that.