### PR TITLE
allow for import "dotenv/config.js"

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "exports": {
     ".": "./lib/main.js",
     "./config": "./config.js",
+    "./config.js": "./config.js",
     "./package.json": "./package.json"
   },
   "types": "types/index.d.ts",


### PR DESCRIPTION
Adding `dotenv/config` as a named export in 8.5.0 had the side effect of `dotenv/config.js` no longer being recognised as an import path.

For example, after upgrading to 9.0.0, I got the following error:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './config.js' is not defined by "exports" in /Users/paulrobertlloyd/Sites/indiekit/node_modules/dotenv/package.json imported from /Users/paulrobertlloyd/Sites/indiekit/packages/indiekit/tests/unit/middleware/indieauth.js
```

Some linters enforce using file extensions in imports, i.e. [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md) and [eslint-plugin-node](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/file-extension-in-import.md).

Explicitly adding `dotenv/config.js` ensures projects following this style can continue to use the `.js` extension when importing `dotenv`.