### PR TITLE
chore: add node.js v16 to ci tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
     - nodejs_version: "10"
     - nodejs_version: "12"
     - nodejs_version: "14"
+    - nodejs_version: "16"
 
 # Install scripts. (runs after repo cloning)
 install:


### PR DESCRIPTION
btw, **v10** is EOL. not sure if you would want to remove it from the ci and the support?

https://nodejs.org/en/about/releases/