### PR TITLE
fix: dotenv/main debug option not work 

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -91,7 +91,7 @@ function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ 
     if (options.encoding != null) {
       encoding = options.encoding
     }
-    debug = Boolean(options.debug);
+    debug = Boolean(options.debug)
   }
 
   try {

--- a/lib/main.js
+++ b/lib/main.js
@@ -91,9 +91,7 @@ function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ 
     if (options.encoding != null) {
       encoding = options.encoding
     }
-    if (options.debug != null) {
-      debug = true
-    }
+    debug = Boolean(options.debug);
   }
 
   try {


### PR DESCRIPTION
fix the issue [548](https://github.com/motdotla/dotenv/issues/548) 
All those will active debug mode:
```
  dotenv.config({ debug: true })
  dotenv.config({ debug: 1 })
  dotenv.config({ debug: 'some string' })
```

And belows will  not:

```
  dotenv.config({ debug: false })
  dotenv.config({ debug: null })
  dotenv.config({ })
  dotenv.config({ debug: 0 })
```


