### PR TITLE
feat: Add support for default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,18 @@ You may specify the encoding of your file containing environment variables.
 require('dotenv').config({ encoding: 'latin1' })
 ```
 
+#### Defaults
+
+Default: `{}`
+
+You may specify default environment variables to inject when not found in your `.env` file.
+If a variable key is found in both your `.env` file and your default values, the value
+in your `.env` file will override the default value.
+
+```js
+require('dotenv').config({ defaults: { PORT: 3000 } })
+```
+
 #### Debug
 
 Default: `false`

--- a/lib/main.js
+++ b/lib/main.js
@@ -37,7 +37,7 @@ const NEWLINES_MATCH = /\r\n|\n|\r/
 // Parses src into an Object
 function parse (src /*: string | Buffer */, options /*: ?DotenvParseOptions */) /*: DotenvParseOutput */ {
   const debug = Boolean(options && options.debug)
-  const defaults /* object */ = (options && options.defaults) ? options.defaults : {}
+  const defaults /*: Object */ = (options && options.defaults) ? options.defaults : {}
   const obj = {}
 
   // convert Buffers before splitting into lines and processing

--- a/lib/main.js
+++ b/lib/main.js
@@ -37,6 +37,7 @@ const NEWLINES_MATCH = /\r\n|\n|\r/
 // Parses src into an Object
 function parse (src /*: string | Buffer */, options /*: ?DotenvParseOptions */) /*: DotenvParseOutput */ {
   const debug = Boolean(options && options.debug)
+  const defaults /* object */ = (options && options.defaults) ? options.defaults : {}
   const obj = {}
 
   // convert Buffers before splitting into lines and processing
@@ -65,13 +66,26 @@ function parse (src /*: string | Buffer */, options /*: ?DotenvParseOptions */) 
         val = val.trim()
       }
 
+      // If key specified as a default val, remove it
+      if (Object.prototype.hasOwnProperty.call(defaults, key)) {
+        delete defaults[key]
+      }
+
       obj[key] = val
     } else if (debug) {
       log(`did not match key and value when parsing line ${idx + 1}: ${line}`)
     }
   })
 
-  return obj
+  /*
+  At this point remaining default keys were not found
+  and need to be injected into out parsed object
+  */
+  if (debug) {
+    log(`using default values: ${defaults}`)
+  }
+
+  return Object.assign(obj, defaults)
 }
 
 function resolveHome (envPath) {

--- a/tests/test-parse.js
+++ b/tests/test-parse.js
@@ -9,7 +9,7 @@ const dotenv = require('../lib/main')
 
 const parsed = dotenv.parse(fs.readFileSync('tests/.env', { encoding: 'utf8' }))
 
-t.plan(28)
+t.plan(29)
 
 t.type(parsed, Object, 'should return an object')
 
@@ -69,14 +69,26 @@ t.same(NPayload, expectedPayload, 'can parse (\\n) line endings')
 const RNPayload = dotenv.parse(Buffer.from('SERVER=localhost\r\nPASSWORD=password\r\nDB=tests\r\n'))
 t.same(RNPayload, expectedPayload, 'can parse (\\r\\n) line endings')
 
+// test default values
+const expectedDefPayload = { SERVER: 'localhost', PASSWORD: 'password', DB: 'tests', PORT: 3000, A_VAR: 'testing' }
+const DefPayload = dotenv.parse(Buffer.from('SERVER=localhost\nPASSWORD=password\nDB=tests\n'), {
+  defaults: {
+    PORT: 3000,
+    A_VAR: 'testing',
+    SERVER: '127.0.0.1'
+  }
+})
+
+t.same(DefPayload, expectedDefPayload, 'can parse with default values')
+
 // test debug path
 let logStub = sinon.stub(console, 'log')
 dotenv.parse(Buffer.from('what is this'), { debug: true })
-t.ok(logStub.calledOnce)
+t.ok(logStub.calledTwice)
 logStub.restore()
 
 // test that debug in windows (\r\n lines) logs just once per line
 logStub = sinon.stub(console, 'log')
 dotenv.parse(Buffer.from('HEY=there\r\n'), { debug: true })
-t.ok(logStub.calledOnce)
+t.ok(logStub.calledTwice)
 logStub.restore()


### PR DESCRIPTION
Added support for default values when a variable is undefined as proposed within issue #552.

Changes:
- dotenv parse function changed to support a new `options.defaults` property. Specified defaults will be added to a final parsed object only if respective key was not encountered within `.env` file.
- Updated TAP tests to test new default value functionality and adjust to the new number of log calls made within function.
- README's options subsection updated to show usage of the **defaults** option.