### PR TITLE
[feat] add console.error

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -110,6 +110,7 @@ function config (options /*: ?DotenvConfigOptions */) /*: DotenvConfigOutput */ 
 
     return { parsed }
   } catch (e) {
+    console.error(e);
     return { error: e }
   }
 }


### PR DESCRIPTION

lib/main.js - 113 line
```
try {
    // specifying an encoding returns a string instead of a buffer
    const parsed = parse(fs.readFileSync(dotenvPath, { encoding }), { debug })

    Object.keys(parsed).forEach(function (key) {
      if (!Object.prototype.hasOwnProperty.call(process.env, key)) {
        process.env[key] = parsed[key]
      } else if (debug) {
        log(`"${key}" is already defined in \`process.env\` and will not be overwritten`)
      }
    })

    return { parsed }
  } catch (e) {
    console.error(e);
    return { error: e }
  }
```



What do you think expose it to the outside? 
Because there was no proper error message. 
so many people ask the same question. Like me. ( wrong path.. etc...)
i don't know until put in console.error(e) 

https://stackoverflow.com/questions/42335016/dotenv-file-is-not-loading-environment-variables