### PR TITLE
explicitly require process

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -23,6 +23,7 @@ type DotenvConfigOutput = {
 
 const fs = require('fs')
 const path = require('path')
+const process = require('process')
 const os = require('os')
 
 function log (message /*: string */) {


### PR DESCRIPTION
https://nodejs.org/api/process.html#process

> While it is available as a global, it is recommended to explicitly access it via require or import.