### PR TITLE
Interpret # as start of comment only if preceded by whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## [Unreleased](https://github.com/motdotla/dotenv/compare/v14.3.0...master)
 
+- Interpret `#` as start of comment only if preceded by whitespace
+
 ## [14.3.0](https://github.com/motdotla/dotenv/compare/v14.2.0...v14.3.0)
 
 - Add `multiline` option 🎉 ([#486](https://github.com/motdotla/dotenv/pull/486))

--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ The parsing engine currently supports the following rules:
 - `BASIC=basic` becomes `{BASIC: 'basic'}`
 - empty lines are skipped
 - lines beginning with `#` are treated as comments
+- whitespace followed by `#` marks the beginning of an inline comment (unless when the value is wrapped in quotes)
 - empty values become empty strings (`EMPTY=` becomes `{EMPTY: ''}`)
 - inner quotes are maintained (think JSON) (`JSON={"foo": "bar"}` becomes `{JSON:"{\"foo\": \"bar\"}"`)
 - whitespace is removed from both ends of unquoted values (see more on [`trim`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/Trim)) (`FOO=  some value  ` becomes `{FOO: 'some value'}`)

--- a/lib/main.js
+++ b/lib/main.js
@@ -7,7 +7,7 @@ function log (message) {
 }
 
 const NEWLINE = '\n'
-const RE_INI_KEY_VAL = /^\s*([\w.-]+)\s*=\s*("[^"]*"|'[^']*'|[^#]*)?(\s*|\s*#.*)?$/
+const RE_INI_KEY_VAL = /^\s*([\w.-]+)\s*=\s*("[^"]*"|'[^']*'|.*?)(\s+#.*)?$/
 const RE_NEWLINES = /\\n/g
 const NEWLINES_MATCH = /\r\n|\n|\r/
 

--- a/tests/.env
+++ b/tests/.env
@@ -16,6 +16,7 @@ DONT_EXPAND_SQUOTED='dontexpand\nnewlines'
 INLINE_COMMENTS=inline comments # work #very #well
 INLINE_COMMENTS_SINGLE_QUOTES='inline comments outside of #singlequotes' # work
 INLINE_COMMENTS_DOUBLE_QUOTES="inline comments outside of #doublequotes" # work
+INLINE_COMMENTS_SPACE=inline comments must start with#space
 EQUAL_SIGNS=equals==
 RETAIN_INNER_QUOTES={"foo": "bar"}
 RETAIN_LEADING_DQUOTE="retained

--- a/tests/test-parse.js
+++ b/tests/test-parse.js
@@ -7,7 +7,7 @@ const dotenv = require('../lib/main')
 
 const parsed = dotenv.parse(fs.readFileSync('tests/.env', { encoding: 'utf8' }))
 
-t.plan(34)
+t.plan(35)
 
 t.type(parsed, Object, 'should return an object')
 
@@ -42,6 +42,8 @@ t.equal(parsed.INLINE_COMMENTS, 'inline comments', 'ignores inline comments')
 t.equal(parsed.INLINE_COMMENTS_SINGLE_QUOTES, 'inline comments outside of #singlequotes', 'ignores inline comments, but respects # character inside of single quotes')
 
 t.equal(parsed.INLINE_COMMENTS_DOUBLE_QUOTES, 'inline comments outside of #doublequotes', 'ignores inline comments, but respects # character inside of double quotes')
+
+t.equal(parsed.INLINE_COMMENTS_SPACE, 'inline comments must start with#space', 'respects # character in values when it is not preceded by a space character')
 
 t.equal(parsed.EQUAL_SIGNS, 'equals==', 'respects equals signs in values')
 


### PR DESCRIPTION
It looks like https://github.com/motdotla/dotenv/pull/568 introduced a breaking change for more people/organizations than I anticipated. This PR changes this so that inline comments have to start with a whitespace character before the `#`, making it much less likely for people upgrading from dotenv < version 14 to break things. Technically, this is again a breaking change, though, for people already using version 14 and using `#` as an inline comment without a preceding whitespace character 😅 

fixes https://github.com/motdotla/dotenv/issues/601

(feel free to close, e.g. in case you have something else in mind like a feature flag for inline comments)