### PR TITLE
patch for 14.3.0, add back explicit module.exports #605

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -137,4 +137,6 @@ const DotenvModule = {
   parse
 }
 
+module.exports.config = DotenvModule.config
+module.exports.parse = DotenvModule.parse
 module.exports = DotenvModule


### PR DESCRIPTION
To preserve backwards compatibility with `14.3.0` this re-introduces the exports in place prior, while keeping the new default.

Details of issue are in #605

**Please note:**
I can see this PR not being needed. The changes introduced in `14.3.0` could be considered the responsibility of the implementer, not `dotenv`. 

In which case this could be considered a `README` update (separate PR), not a patch or breaking change.

If this is accepted, I would see these lines of code not existing in the next breaking version. 😆 

