### PR TITLE
Add support for base64 encoded environment config

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -8,6 +8,15 @@ const LINE = /(?:^|^)\s*(?:export\s+)?([\w.-]+)(?:\s*=\s*?|:\s+?)(\s*'(?:\\'|[^'
 function parse (src) {
   const obj = {}
 
+  // Check if src is base64 encoded
+  const base64Test = /^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$/g
+  const isBase64Encoded = base64Test.test(src)
+
+  // If true, then decode base64
+  if (isBase64Encoded) {
+    src = Buffer.from(src, 'base64')
+  }
+
   // Convert buffer to string
   let lines = src.toString()
 

--- a/tests/test-parse-multiline.js
+++ b/tests/test-parse-multiline.js
@@ -60,3 +60,18 @@ t.same(NPayload, expectedPayload, 'can parse (\\n) line endings')
 
 const RNPayload = dotenv.parse(Buffer.from('SERVER=localhost\r\nPASSWORD=password\r\nDB=tests\r\n'))
 t.same(RNPayload, expectedPayload, 'can parse (\\r\\n) line endings')
+
+const base64EncodedPayload = dotenv.parse(Buffer.from('SERVER=localhost\r\nPASSWORD=password\r\nDB=tests\r\n').toString('base64'))
+t.same(base64EncodedPayload, expectedPayload, 'can parse base64 encoded payload into object')
+
+const payloadBase64 = dotenv.parse(Buffer.from('BASE64=true').toString('base64'))
+t.equal(payloadBase64.BASE64, 'true', 'should parse a base64 string into an object')
+
+const RPayloadBase64 = dotenv.parse(Buffer.from('SERVER=localhost\rPASSWORD=password\rDB=tests\r').toString('base64'))
+t.same(RPayloadBase64, expectedPayload, 'can parse (\\r) line endings in base64')
+
+const NPayloadBase64 = dotenv.parse(Buffer.from('SERVER=localhost\nPASSWORD=password\nDB=tests\n').toString('base64'))
+t.same(NPayloadBase64, expectedPayload, 'can parse (\\n) line endings in base64')
+
+const RNPayloadBase64 = dotenv.parse(Buffer.from('SERVER=localhost\r\nPASSWORD=password\r\nDB=tests\r\n').toString('base64'))
+t.same(RNPayloadBase64, expectedPayload, 'can parse (\\r\\n) line endings in base64')

--- a/tests/test-parse.js
+++ b/tests/test-parse.js
@@ -96,3 +96,18 @@ t.same(NPayload, expectedPayload, 'can parse (\\n) line endings')
 
 const RNPayload = dotenv.parse(Buffer.from('SERVER=localhost\r\nPASSWORD=password\r\nDB=tests\r\n'))
 t.same(RNPayload, expectedPayload, 'can parse (\\r\\n) line endings')
+
+const base64EncodedPayload = dotenv.parse(Buffer.from('SERVER=localhost\r\nPASSWORD=password\r\nDB=tests\r\n').toString('base64'))
+t.same(base64EncodedPayload, expectedPayload, 'can parse base64 encoded payload into object')
+
+const payloadBase64 = dotenv.parse(Buffer.from('BASE64=true').toString('base64'))
+t.equal(payloadBase64.BASE64, 'true', 'should parse a base64 string into an object')
+
+const RPayloadBase64 = dotenv.parse(Buffer.from('SERVER=localhost\rPASSWORD=password\rDB=tests\r').toString('base64'))
+t.same(RPayloadBase64, expectedPayload, 'can parse (\\r) line endings in base64')
+
+const NPayloadBase64 = dotenv.parse(Buffer.from('SERVER=localhost\nPASSWORD=password\nDB=tests\n').toString('base64'))
+t.same(NPayloadBase64, expectedPayload, 'can parse (\\n) line endings in base64')
+
+const RNPayloadBase64 = dotenv.parse(Buffer.from('SERVER=localhost\r\nPASSWORD=password\r\nDB=tests\r\n').toString('base64'))
+t.same(RNPayloadBase64, expectedPayload, 'can parse (\\r\\n) line endings in base64')


### PR DESCRIPTION
dotenv has support has Buffer but not for base64. So I added support for it. 

This will make the environment variables more secure. 

Eg, There is a config 

SERVER=localhost\nPASSWORD=password\nDB=tests\n.
Then it gets encoded to U0VSVkVSPWxvY2FsaG9zdFxuUEFTU1dPUkQ9cGFzc3dvcmRcbkRCPXRlc3RzXG4=

On decoding  and parsing it we get the required key value pairs. 

 /^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$/g
This regex will test if the config is in base64 form. 

Then we decode it using src = Buffer.from(src, 'base64').

I have added test cases for multiple cases.

Please let me know, if any other changes are required for this update