### PR TITLE
fix: update typo on readme concerning return line documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Kh9NV...
 Alternatively, you can double quote strings and use the `\n` character:
 
 ```dosini
-PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\Kh9NV...\n-----END DSA PRIVATE KEY-----\n"
+PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\nKh9NV...\n-----END DSA PRIVATE KEY-----\n"
 ```
 
 ### Comments


### PR DESCRIPTION
references #642 

There was a character missing in the README.md documentation
The example was showing that return line was possible but the `\n` was missing