### PR TITLE
Feature/esm export

### DIFF
--- a/lib/main.mjs
+++ b/lib/main.mjs
@@ -1,0 +1,109 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+const LINE = /(?:^|^)\s*(?:export\s+)?([\w.-]+)(?:\s*=\s*?|:\s+?)(\s*'(?:\\'|[^'])*'|\s*"(?:\\"|[^"])*"|\s*`(?:\\`|[^`])*`|[^#\r\n]+)?\s*(?:#.*)?(?:$|$)/mg
+
+// Parser src into an Object
+function parse (src) {
+  const obj = {}
+
+  // Convert buffer to string
+  let lines = src.toString()
+
+  // Convert line breaks to same format
+  lines = lines.replace(/\r\n?/mg, '\n')
+
+  let match
+  while ((match = LINE.exec(lines)) != null) {
+    const key = match[1]
+
+    // Default undefined or null to empty string
+    let value = (match[2] || '')
+
+    // Remove whitespace
+    value = value.trim()
+
+    // Check if double quoted
+    const maybeQuote = value[0]
+
+    // Remove surrounding quotes
+    value = value.replace(/^(['"`])([\s\S]*)\1$/mg, '$2')
+
+    // Expand newlines if double quoted
+    if (maybeQuote === '"') {
+      value = value.replace(/\\n/g, '\n')
+      value = value.replace(/\\r/g, '\r')
+    }
+
+    // Add to object
+    obj[key] = value
+  }
+
+  return obj
+}
+
+function _log (message) {
+  console.log(`[dotenv][DEBUG] ${message}`)
+}
+
+function _resolveHome (envPath) {
+  return envPath[0] === '~' ? path.join(os.homedir(), envPath.slice(1)) : envPath
+}
+
+// Populates process.env from .env file
+function config (options) {
+  let dotenvPath = path.resolve(process.cwd(), '.env')
+  let encoding = 'utf8'
+  const debug = Boolean(options && options.debug)
+  const override = Boolean(options && options.override)
+
+  if (options) {
+    if (options.path != null) {
+      dotenvPath = _resolveHome(options.path)
+    }
+    if (options.encoding != null) {
+      encoding = options.encoding
+    }
+  }
+
+  try {
+    // Specifying an encoding returns a string instead of a buffer
+    const parsed = DotenvModule.parse(fs.readFileSync(dotenvPath, { encoding }))
+
+    Object.keys(parsed).forEach(function (key) {
+      if (!Object.prototype.hasOwnProperty.call(process.env, key)) {
+        process.env[key] = parsed[key]
+      } else {
+        if (override === true) {
+          process.env[key] = parsed[key]
+        }
+
+        if (debug) {
+          if (override === true) {
+            _log(`"${key}" is already defined in \`process.env\` and WAS overwritten`)
+          } else {
+            _log(`"${key}" is already defined in \`process.env\` and was NOT overwritten`)
+          }
+        }
+      }
+    })
+
+    return { parsed }
+  } catch (e) {
+    if (debug) {
+      _log(`Failed to load ${dotenvPath} ${e.message}`)
+    }
+
+    return { error: e }
+  }
+}
+
+const DotenvModule = {
+  config,
+  parse
+}
+
+export const config = DotenvModule.config;
+export const parse = DotenvModule.parse;
+export default DotenvModule;

--- a/lib/main.mjs
+++ b/lib/main.mjs
@@ -5,7 +5,7 @@ import os from 'os';
 const LINE = /(?:^|^)\s*(?:export\s+)?([\w.-]+)(?:\s*=\s*?|:\s+?)(\s*'(?:\\'|[^'])*'|\s*"(?:\\"|[^"])*"|\s*`(?:\\`|[^`])*`|[^#\r\n]+)?\s*(?:#.*)?(?:$|$)/mg
 
 // Parser src into an Object
-function parse (src) {
+export function parse (src) {
   const obj = {}
 
   // Convert buffer to string
@@ -52,7 +52,7 @@ function _resolveHome (envPath) {
 }
 
 // Populates process.env from .env file
-function config (options) {
+export function config (options) {
   let dotenvPath = path.resolve(process.cwd(), '.env')
   let encoding = 'utf8'
   const debug = Boolean(options && options.debug)
@@ -104,6 +104,4 @@ const DotenvModule = {
   parse
 }
 
-export const config = DotenvModule.config;
-export const parse = DotenvModule.parse;
 export default DotenvModule;

--- a/lib/main.mjs
+++ b/lib/main.mjs
@@ -1,6 +1,6 @@
-import fs from 'fs';
-import path from 'path';
-import os from 'os';
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
 
 const LINE = /(?:^|^)\s*(?:export\s+)?([\w.-]+)(?:\s*=\s*?|:\s+?)(\s*'(?:\\'|[^'])*'|\s*"(?:\\"|[^"])*"|\s*`(?:\\`|[^`])*`|[^#\r\n]+)?\s*(?:#.*)?(?:$|$)/mg
 
@@ -104,4 +104,4 @@ const DotenvModule = {
   parse
 }
 
-export default DotenvModule;
+export default DotenvModule

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": {
       "require": "./lib/main.js",
+      "import": "./lib/main.mjs",
       "types": "./lib/main.d.ts",
       "default": "./lib/main.js"
     },


### PR DESCRIPTION
A bug in either node/cjs lexer causes ES6 imports of CJS to fail in some shared environments (steps to reproduce are including in the issue I made here -> https://github.com/nodejs/node/issues/42222)

Although this should ultimately be "solved" in node itself, I was wondering if this ESM export is a potential step dotenv is willing to take.

I'd opened a discussion (Related to this issue - https://github.com/motdotla/dotenv/discussions/640), but didn't get any feedback, so thought an MR might be the next step.

This does fix the memory issue for me, when I install dotenv from my fork. 