### PR TITLE
Parsed file entries can be undefined

### DIFF
--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -1,9 +1,7 @@
 // TypeScript Version: 3.0
 /// <reference types="node" />
 
-export interface DotenvParseOutput {
-  [name: string]: string;
-}
+export type DotenvParseOutput = NodeJS.Dict<string>
 
 /**
  * Parses a string or buffer in the .env file format into an object.

--- a/tests/types/test.ts
+++ b/tests/types/test.ts
@@ -2,7 +2,7 @@ import { config, parse } from "dotenv";
 
 const env = config();
 const dbUrl: string | null =
-  env.error || !env.parsed ? null : env.parsed["BASIC"];
+  env.error || !env.parsed ? null : env.parsed["BASIC"] ?? "";
 
 config({
   path: ".env-example",
@@ -13,7 +13,9 @@ config({
 parse("test");
 
 const parsed = parse("NODE_ENV=production\nDB_HOST=a.b.c");
-const dbHost: string = parsed["DB_HOST"];
+const dbHost: string = parsed["DB_HOST"] ?? "";
+const dbHostUndef: undefined = parsed["DB_HOST"] as undefined;
 
 const parsedFromBuffer = parse(new Buffer("JUSTICE=league\n"));
-const justice: string = parsedFromBuffer["JUSTICE"];
+const justice: string = parsedFromBuffer["JUSTICE"] ?? "";
+const justiceUndef: undefined = parsedFromBuffer["JUSTICE"] as undefined;


### PR DESCRIPTION
Assuming that the file contains every entry you put in the code is untrue. This change brings the output type into line with NodeJS process.env.

BREAKING CHANGE: Code that makes the assumption that the values are defined will now fail to compile. Validate your inputs.

Fixes #650 