### PR TITLE
Add a load function for loading .env without applying it

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ You can load the `.env` file without updating `process.env` using the `load` fun
 ```javascript
 const dotenv = require('dotenv')
 const config = dotenv.load() // will return an object
-console.log(typeof config, config) // object { BASIC : 'basic' }
 ```
 
 ### Preload

--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ const config = dotenv.parse(buf) // will return an object
 console.log(typeof config, config) // object { BASIC : 'basic' }
 ```
 
+You can load the `.env` file without updating `process.env` using the `load` function:
+
+```javascript
+const dotenv = require('dotenv')
+const buf = Buffer.from('BASIC=basic')
+const config = dotenv.load() // will return an object
+console.log(typeof config, config) // object { BASIC : 'basic' }
+```
+
 ### Preload
 
 You can use the `--require` (`-r`) [command line option](https://nodejs.org/api/cli.html#-r---require-module) to preload dotenv. By doing this, you do not need to require and load dotenv in your application code.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ You can load the `.env` file without updating `process.env` using the `load` fun
 
 ```javascript
 const dotenv = require('dotenv')
-const buf = Buffer.from('BASIC=basic')
 const config = dotenv.load() // will return an object
 console.log(typeof config, config) // object { BASIC : 'basic' }
 ```

--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -2,7 +2,7 @@
 /// <reference types="node" />
 
 export interface DotenvParseOutput {
-  [name: string]: string;
+  [name: string]: string | undefined;
 }
 
 /**
@@ -18,7 +18,7 @@ export function parse<T extends DotenvParseOutput = DotenvParseOutput>(
   src: string | Buffer
 ): T;
 
-export interface DotenvConfigOptions {
+export interface DotenvLoadOptions {
   /**
    * Default: `path.resolve(process.cwd(), '.env')`
    *
@@ -36,6 +36,18 @@ export interface DotenvConfigOptions {
    * example: `require('dotenv').config({ encoding: 'latin1' })`
    */
   encoding?: string;
+}
+
+/**
+ * Load `.env` file contents and return key/value pairs as an object.
+ *
+ * @param options - additional options. example: `{ path: './custom/path', encoding: 'latin1' }`
+ * @returns an object with the keys and values loaded from the `.env` file
+ */
+export function load(options?: DotenvLoadOptions): DotenvParseOutput;
+
+
+export interface DotenvConfigOptions extends DotenvLoadOptions {
 
   /**
    * Default: `false`
@@ -71,3 +83,4 @@ export interface DotenvConfigOutput {
  *
  */
 export function config(options?: DotenvConfigOptions): DotenvConfigOutput;
+

--- a/lib/main.js
+++ b/lib/main.js
@@ -51,12 +51,9 @@ function _resolveHome (envPath) {
   return envPath[0] === '~' ? path.join(os.homedir(), envPath.slice(1)) : envPath
 }
 
-// Populates process.env from .env file
-function config (options) {
+function load (options) {
   let dotenvPath = path.resolve(process.cwd(), '.env')
   let encoding = 'utf8'
-  const debug = Boolean(options && options.debug)
-  const override = Boolean(options && options.override)
 
   if (options) {
     if (options.path != null) {
@@ -67,9 +64,22 @@ function config (options) {
     }
   }
 
+  // Specifying an encoding returns a string instead of a buffer
+  return DotenvModule.parse(fs.readFileSync(dotenvPath, { encoding }))
+}
+
+// Populates process.env from .env file
+function config (options) {
+  const debug = Boolean(options && options.debug)
+  const override = Boolean(options && options.override)
+
+  let dotenvPath = path.resolve(process.cwd(), '.env')
+  if (options && options.path != null) {
+    dotenvPath = _resolveHome(options.path)
+  }
+
   try {
-    // Specifying an encoding returns a string instead of a buffer
-    const parsed = DotenvModule.parse(fs.readFileSync(dotenvPath, { encoding }))
+    const parsed = load(options)
 
     Object.keys(parsed).forEach(function (key) {
       if (!Object.prototype.hasOwnProperty.call(process.env, key)) {
@@ -101,9 +111,11 @@ function config (options) {
 
 const DotenvModule = {
   config,
+  load,
   parse
 }
 
 module.exports.config = DotenvModule.config
+module.exports.load = DotenvModule.load
 module.exports.parse = DotenvModule.parse
 module.exports = DotenvModule

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "dotenv",
       "version": "16.0.0",
       "license": "BSD-2-Clause",
       "devDependencies": {

--- a/tests/test-load.js
+++ b/tests/test-load.js
@@ -1,0 +1,79 @@
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+const sinon = require('sinon')
+const t = require('tap')
+
+const dotenv = require('../lib/main')
+
+const mockParseResponse = { test: 'foo' }
+let readFileSyncStub
+let parseStub
+
+t.beforeEach(() => {
+  readFileSyncStub = sinon.stub(fs, 'readFileSync').returns('test=foo')
+  parseStub = sinon.stub(dotenv, 'parse').returns(mockParseResponse)
+})
+
+t.afterEach(() => {
+  readFileSyncStub.restore()
+  parseStub.restore()
+})
+
+t.test('takes option for path', ct => {
+  ct.plan(1)
+
+  const testPath = 'tests/.env'
+  dotenv.load({ path: testPath })
+
+  ct.equal(readFileSyncStub.args[0][0], testPath)
+})
+
+t.test('takes option for path along with home directory char ~', ct => {
+  ct.plan(2)
+  const mockedHomedir = '/Users/dummy'
+  const homedirStub = sinon.stub(os, 'homedir').returns(mockedHomedir)
+  const testPath = '~/.env'
+  dotenv.load({ path: testPath })
+
+  ct.equal(readFileSyncStub.args[0][0], path.join(mockedHomedir, '.env'))
+  ct.ok(homedirStub.called)
+  homedirStub.restore()
+})
+
+t.test('takes option for encoding', ct => {
+  ct.plan(1)
+
+  const testEncoding = 'latin1'
+  dotenv.load({ encoding: testEncoding })
+
+  ct.equal(readFileSyncStub.args[0][1].encoding, testEncoding)
+})
+
+t.test('reads path with encoding, returns parsed version', ct => {
+  ct.plan(2)
+
+  const res = dotenv.load()
+
+  ct.same(res, mockParseResponse)
+  ct.equal(readFileSyncStub.callCount, 1)
+})
+
+t.test('does not modify process.env', ct => {
+  ct.plan(2)
+
+  const before = JSON.stringify(process.env)
+  const env = dotenv.load()
+  const after = JSON.stringify(process.env)
+
+  ct.equal(env && env.test, mockParseResponse.test)
+  ct.equal(before, after)
+})
+
+t.test('throws errors thrown from reading file or parsing', ct => {
+  ct.plan(1)
+
+  readFileSyncStub.throws()
+  ct.throws(() => dotenv.load(), Error)
+})

--- a/tests/types/test.ts
+++ b/tests/types/test.ts
@@ -1,7 +1,7 @@
 import { config, parse } from "dotenv";
 
 const env = config();
-const dbUrl: string | null =
+const dbUrl: string | null | undefined =
   env.error || !env.parsed ? null : env.parsed["BASIC"];
 
 config({
@@ -13,7 +13,7 @@ config({
 parse("test");
 
 const parsed = parse("NODE_ENV=production\nDB_HOST=a.b.c");
-const dbHost: string = parsed["DB_HOST"];
+const dbHost: string | undefined = parsed["DB_HOST"];
 
 const parsedFromBuffer = parse(new Buffer("JUSTICE=league\n"));
-const justice: string = parsedFromBuffer["JUSTICE"];
+const justice: string | undefined = parsedFromBuffer["JUSTICE"];


### PR DESCRIPTION

It seemed unexpectedly hard to load and parse the `.env` file from the default path (or `$DOTENV_CONFIG_PATH`).  This seemed like a pretty simple refactor that could come in handy from time to time.

In my case I wanted to apply a whitelist to the results, so I could use this function and filter out the keys that I don't want before applying to `process.env`.
