### PR TITLE
[1/2] fixes dotenv-expand/config with env or cli args

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "./config": "./config.js",
     "./config.js": "./config.js",
     "./lib/env-options": "./lib/env-options.js",
+    "./lib/env-options.js": "./lib/env-options.js",
     "./lib/cli-options": "./lib/cli-options.js",
+    "./lib/cli-options.js": "./lib/cli-options.js",
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     },
     "./config": "./config.js",
     "./config.js": "./config.js",
+    "./lib/env-options": "./lib/env-options.js",
+    "./lib/cli-options": "./lib/cli-options.js",
     "./package.json": "./package.json"
   },
   "scripts": {


### PR DESCRIPTION
I discovered that when using [dotenv-expand](https://www.npmjs.com/package/dotenv-expand) in preload env and cli args are not working, so I made two pull requests (the former in [dotenv](https://github.com/motdotla/dotenv) and the latter in [dotenv-expand](https://github.com/motdotla/dotenv-expand) to fix it.

I used [dotenv#355](https://github.com/motdotla/dotenv/pull/355) for reference.