### PR TITLE
better way to use config()

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@ console.log(process.env) // remove this after you've confirmed it working
 .. or using ES6?
 
 ```javascript
-import * as dotenv from 'dotenv' // see https://github.com/motdotla/dotenv#how-do-i-use-dotenv-with-import
-dotenv.config()
+import "dotenv/config" from "dotenv" //better way to config in es6
 import express from 'express'
 ```
 


### PR DESCRIPTION
I think there is a better way to import config function. It solves a bug, that happens when some dependencies will have null in .env file, because dotenv module is doesn't loaded
```javascript
import * as dotenv from 'dotenv' // see https://github.com/motdotla/dotenv#how-do-i-use-dotenv-with-import
dotenv.config()
import "somemodule" //if in this module we needs environment we may have an error, that happens because to this moment dotenv isn't loaded because of es6 module loading peculiarities
```