### PR TITLE
Add Stricter Encoding type

### DIFF
--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -35,7 +35,7 @@ export interface DotenvConfigOptions {
    *
    * example: `require('dotenv').config({ encoding: 'latin1' })`
    */
-  encoding?: string;
+  encoding?: BufferEncoding;
 
   /**
    * Default: `false`


### PR DESCRIPTION
The motive is to introduce stricter type & offer autocomplete in code editors as this change directly gathers possible encoding choices from Node.js itself