### PR TITLE
More characters for env keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ The parsing engine currently supports the following rules:
 
 - `BASIC=basic` becomes `{BASIC: 'basic'}`
 - empty lines are skipped
+- variable names must consist of alphanumeric characters and `_.-{}[]()<>`
 - lines beginning with `#` are treated as comments
 - `#` marks the beginning of a comment (unless when the value is wrapped in quotes)
 - empty values become empty strings (`EMPTY=` becomes `{EMPTY: ''}`)

--- a/lib/main.js
+++ b/lib/main.js
@@ -5,7 +5,7 @@ const packageJson = require('../package.json')
 
 const version = packageJson.version
 
-const LINE = /(?:^|^)\s*(?:export\s+)?([\w.-]+)(?:\s*=\s*?|:\s+?)(\s*'(?:\\'|[^'])*'|\s*"(?:\\"|[^"])*"|\s*`(?:\\`|[^`])*`|[^#\r\n]+)?\s*(?:#.*)?(?:$|$)/mg
+const LINE = /(?:^|^)\s*(?:export\s+)?([\w(){}<>[\].-]+)(?:\s*=\s*?|:\s+?)(\s*'(?:\\'|[^'])*'|\s*"(?:\\"|[^"])*"|\s*`(?:\\`|[^`])*`|[^#\r\n]+)?\s*(?:#.*)?(?:$|$)/mg
 
 // Parser src into an Object
 function parse (src) {

--- a/tests/.env
+++ b/tests/.env
@@ -37,3 +37,7 @@ RETAIN_INNER_QUOTES_AS_BACKTICKS=`{"foo": "bar's"}`
 TRIM_SPACE_FROM_UNQUOTED=    some spaced out string
 USERNAME=therealnerdybeast@example.tld
     SPACED_KEY = parsed
+SQUARE_BRACKETS[0]=square brackets work
+ROUND_BRACKETS(1)=round brackets work
+ANGLE_BRACKETS<bar>=angle brackets work
+CURLY_BRACKETS{foo}=curly brackets work

--- a/tests/test-parse.js
+++ b/tests/test-parse.js
@@ -83,6 +83,14 @@ t.equal(parsed.USERNAME, 'therealnerdybeast@example.tld', 'parses email addresse
 
 t.equal(parsed.SPACED_KEY, 'parsed', 'parses keys and values surrounded by spaces')
 
+t.equal(parsed['SQUARE_BRACKETS[0]'], 'square brackets work', 'square brackets are allowed in environment keys')
+
+t.equal(parsed['ROUND_BRACKETS(1)'], 'round brackets work', 'round brackets are allowed in environment keys')
+
+t.equal(parsed['ANGLE_BRACKETS<bar>'], 'angle brackets work', 'angle brackets are allowed in environment keys')
+
+t.equal(parsed['CURLY_BRACKETS{foo}'], 'curly brackets work', 'curly brackets are allowed in environment keys')
+
 const payload = dotenv.parse(Buffer.from('BUFFER=true'))
 t.equal(payload.BUFFER, 'true', 'should parse a buffer into an object')
 


### PR DESCRIPTION
I noticed some of my env variables were not being loaded at all. After some prodding, It turned out a regex was the culprit, allowing only alphanumeric, underscore, dot and hyphen for variable names.

This PR extends the Regex to allow any kind of bracket (round, square, angle, curly).

I also updated the ReadMe section on how the parser works to specify precisely what kind of characters are allowed in variable names.