### PR TITLE
Add env() function to get key value 

### DIFF
--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -71,3 +71,14 @@ export interface DotenvConfigOutput {
  *
  */
 export function config(options?: DotenvConfigOptions): DotenvConfigOutput;
+
+/**
+ * Loads `.env` file contents into process.env. then get the env vaiable
+ *
+ * See https://docs.dotenv.org
+ *
+ * @param key  example: `env("DB_TOKEN")`
+ * @returns a value for the input key or undefined if not exist 
+ *
+ */
+export function env(key: string): string;

--- a/lib/main.js
+++ b/lib/main.js
@@ -102,11 +102,18 @@ function config (options) {
   }
 }
 
+function env(key){
+  config();
+  return process.env[key];
+}
+
 const DotenvModule = {
   config,
-  parse
+  parse,
+  env
 }
 
 module.exports.config = DotenvModule.config
 module.exports.parse = DotenvModule.parse
+module.exports.env = DotenvModule.env
 module.exports = DotenvModule


### PR DESCRIPTION
using env function is more easier and more readable for getting the value from enviroment vaiable 

before 
```js
require("dotenv").config();

const db_pass = process.env.DB_PASS
console.log(db_pass);

```


after 

```js
const env = require("dotenv").env;

const db_pass = env("DB_PASS")
console.log(db_pass);

```