### PR TITLE
docs: update readme with Fastify reference application

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ See [examples](https://github.com/dotenv-org/examples) of using dotenv with vari
 * [react (typescript)](https://github.com/dotenv-org/examples/tree/master/dotenv-react-typescript)
 * [express](https://github.com/dotenv-org/examples/tree/master/dotenv-express)
 * [nestjs](https://github.com/dotenv-org/examples/tree/master/dotenv-nestjs)
+* [fastify](https://github.com/dotenv-org/examples/tree/master/dotenv-fastify)
 
 ## Documentation
 


### PR DESCRIPTION
This PR updates the README.md file with a reference to a fully working Fastify application that uses dotenv.

This should only merge once the PR (https://github.com/dotenv-org/examples/pull/6) on the `dotenv-org/examples` merges too. It also has more insights and information as to the benefits of the referenced Fastify app with dotenv.