### PR TITLE
chore: reorder the types field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "types": "lib/main.d.ts",
   "exports": {
     ".": {
-      "require": "./lib/main.js",
       "types": "./lib/main.d.ts",
+      "require": "./lib/main.js",
       "default": "./lib/main.js"
     },
     "./config": "./config.js",


### PR DESCRIPTION
Should be the first in the object as required by TypeScript. This is more conducive to TypeScript work.