### PR TITLE
feat: Accept URL as path option

### DIFF
--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -26,7 +26,7 @@ export interface DotenvConfigOptions {
    *
    * example: `require('dotenv').config({ path: '/custom/path/to/.env' })`
    */
-  path?: string;
+  path?: string | URL;
 
   /**
    * Default: `utf8`

--- a/tests/test-config.js
+++ b/tests/test-config.js
@@ -21,10 +21,19 @@ t.afterEach(() => {
   parseStub.restore()
 })
 
-t.test('takes option for path', ct => {
+t.test('takes string for path option', ct => {
   ct.plan(1)
 
   const testPath = 'tests/.env'
+  dotenv.config({ path: testPath })
+
+  ct.equal(readFileSyncStub.args[0][0], testPath)
+})
+
+t.test('takes URL for path option', ct => {
+  ct.plan(1)
+
+  const testPath = new URL('file://home/user/project/.env')
   dotenv.config({ path: testPath })
 
   ct.equal(readFileSyncStub.args[0][0], testPath)


### PR DESCRIPTION
Since Node.js v7.6.0 `fs.readFileSync` accepts `URL` as a path argument.

This PR amends type definition to reflect that: `path` option is declared as `string | URL`.