### PR TITLE
Add debug message if no encoding is specified

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -199,6 +199,10 @@ function _configDotenv (options) {
     }
     if (options.encoding != null) {
       encoding = options.encoding
+    } else {
+      if (debug) {
+        _debug('No encoding is specified. UTF-8 is used by default')
+      }
     }
   }
 


### PR DESCRIPTION
If no encoding is specified in the options, debug will alert the user that UTF-8 will be used as the default.

From my perspective, there were two resolutions to this issue.

1. If no encoding is specified in the options, and debug is enabled, a UTF-8 validation function will determine if the .env file is is UTF-8, and warn the user if it fails.
2. If no encoding is specified in the options, and debug is enabled, a warning will show that UTF-8 is used as the default encoding.

While UTF-8 is one of the few encodings that _can_ be reliably validated without using heuristics, the code to do so is generally not compact or easy to understand, and would require running the validation function on the entire string, in addition to being parsed.

The original issue this fix stems from was a mismatched encoding for .dotenv not conforming with the default UTF-8 (UTF-16-LE was the culprit). Implementing an entire UTF-8 validator function seems to be overkill (both computationally, and code clarity wise) for, from what I can tell, is not a common issue. I think alerting the user of the default encoding _only in debug mode_ is a good compromise to avoid unnecessary bloat.

Please let me know your thoughts. This is my first open source contribution, so any and all critique is welcome. 

Thank you! :)

Closes #657 