### PR TITLE
Add `.github/` to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+.github/
 .nyc_output/
 examples/
 flow-typed/


### PR DESCRIPTION
Just a minor suggestion to omit some unnecessary files from the published package.

On a related note, I'd suggest switching from a blocklist to an allowlist approach. What I mean is to write `.npmignore` such that you list files that should be published instead of files that shouldn't. The main advantage of this approach would be that it avoids publishing files unintentionally (most importantly files that aren't VCS tracked), but comes at the cost of having to be updated if new files should be included in the package. In my personal experience this trade-off is worth it.

The following allowlist `.npmignore` would work for this project (note that `package.json` is always published):

```gitignore
# Ignore everything ...
/*

# Except what needs to be published
!lib/
!CHANGELOG.md
!LICENSE
!README*.md # Covers README.md and README-es.md as well as any other languages added in the future
!config.d.ts
!config.js
```