### PR TITLE
fix missing URL import in types

### DIFF
--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -1,5 +1,6 @@
 // TypeScript Version: 3.0
 /// <reference types="node" />
+import type { URL } from 'node:url';
 
 export interface DotenvParseOutput {
   [name: string]: string;


### PR DESCRIPTION
**What:**

Adds missing import to types.

**Why:**

The types are missing import which results in
```
node_modules/dotenv/lib/main.d.ts:29:19 - error TS2304: Cannot find name 'URL'.

29   path?: string | URL;
```

See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/19799.