### PR TITLE
Can get env variables null-safety

### DIFF
--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -154,3 +154,15 @@ export function populate(processEnv: DotenvPopulateInput, parsed: DotenvPopulate
  *
  */
 export function decrypt(encrypted: string, keyStr: string): string;
+
+/**
+ * Get env variable and throw an error if it is undefined
+ *
+ * See https://docs.dotenv.org
+ *
+ * @param key - the env key
+ * @returns {string | boolean}
+ * @throws {Error} - Cannot locate environment $key in your .env file.
+ *
+ */
+export function get(key: string): string | boolean;

--- a/lib/main.js
+++ b/lib/main.js
@@ -8,6 +8,8 @@ const version = packageJson.version
 
 const LINE = /(?:^|^)\s*(?:export\s+)?([\w.-]+)(?:\s*=\s*?|:\s+?)(\s*'(?:\\'|[^'])*'|\s*"(?:\\"|[^"])*"|\s*`(?:\\`|[^`])*`|[^#\r\n]+)?\s*(?:#.*)?(?:$|$)/mg
 
+const _cache = new Map()
+
 // Parse src into an Object
 function parse (src) {
   const obj = {}
@@ -216,6 +218,8 @@ function configDotenv (options) {
 
 // Populates process.env from .env file
 function config (options) {
+  _cache.set('options', options)
+
   const vaultPath = _vaultPath(options)
 
   // fallback to original dotenv if DOTENV_KEY is not set
@@ -293,6 +297,28 @@ function populate (processEnv, parsed, options = {}) {
   }
 }
 
+function get (key) {
+  let processEnv = process.env
+
+  const options = _cache.get('options')
+
+  if (options && options.processEnv != null) {
+    processEnv = options.processEnv
+  }
+
+  const envValue = processEnv[key]
+
+  if (!envValue) {
+    throw new Error(`Cannot locate environment ${key} in your .env file.`)
+  }
+
+  if (['true', 'false'].includes(envValue)) {
+    return envValue.toLowerCase() === 'true'
+  }
+
+  return envValue
+}
+
 const DotenvModule = {
   configDotenv,
   _configVault,
@@ -300,7 +326,8 @@ const DotenvModule = {
   config,
   decrypt,
   parse,
-  populate
+  populate,
+  get
 }
 
 module.exports.configDotenv = DotenvModule.configDotenv
@@ -310,5 +337,6 @@ module.exports.config = DotenvModule.config
 module.exports.decrypt = DotenvModule.decrypt
 module.exports.parse = DotenvModule.parse
 module.exports.populate = DotenvModule.populate
+module.exports.get = DotenvModule.get
 
 module.exports = DotenvModule

--- a/tests/test-get.js
+++ b/tests/test-get.js
@@ -1,0 +1,57 @@
+const fs = require('fs')
+
+const sinon = require('sinon')
+const t = require('tap')
+
+const dotenv = require('../lib/main')
+
+const mockParseResponse = { test: 'foo', someBool: 'true' }
+let readFileSyncStub
+let parseStub
+
+t.beforeEach(() => {
+  readFileSyncStub = sinon.stub(fs, 'readFileSync').returns('test=foo\nsomeBool=true')
+  parseStub = sinon.stub(dotenv, 'parse').returns(mockParseResponse)
+})
+
+t.afterEach(() => {
+  readFileSyncStub.restore()
+  parseStub.restore()
+})
+
+t.test('get env variable', ct => {
+  ct.plan(1)
+
+  dotenv.config()
+
+  ct.ok(dotenv.get('test') === 'foo')
+})
+
+t.test('get env variable from processEnv', ct => {
+  ct.plan(1)
+
+  const myEnv = { another: 'foo' }
+
+  dotenv.config({ processEnv: myEnv })
+
+  ct.ok(dotenv.get('another') === 'foo')
+})
+
+t.test('get env variable and parse boolean', ct => {
+  ct.plan(2)
+
+  dotenv.config()
+
+  ct.ok(typeof dotenv.get('someBool') === 'boolean')
+  ct.ok(dotenv.get('someBool') === true)
+})
+
+t.test('throws if env variable is not found', ct => {
+  ct.plan(1)
+
+  dotenv.config()
+
+  ct.throws(() => {
+    dotenv.get('notfound')
+  })
+})


### PR DESCRIPTION
In the projects I worked on, I had to create an abstract class or a helper function to validate if the environment variable existed before using it for security and time-saving purposes. 

So I implemented a built-in get accessor for environment variables that primarily does three things:
- Get an env value from the processEnv option or process.env object.
- Parse boolean envs by default
- Throws an exception if the environment is not defined (it saves a lot of debugging time instead of looking up your code to see why the integration is not working when you just git pushed the code).