### PR TITLE
Fix: Redundant code removal.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -303,12 +303,4 @@ const DotenvModule = {
   populate
 }
 
-module.exports.configDotenv = DotenvModule.configDotenv
-module.exports._configVault = DotenvModule._configVault
-module.exports._parseVault = DotenvModule._parseVault
-module.exports.config = DotenvModule.config
-module.exports.decrypt = DotenvModule.decrypt
-module.exports.parse = DotenvModule.parse
-module.exports.populate = DotenvModule.populate
-
 module.exports = DotenvModule


### PR DESCRIPTION
I was stuck integrating `dotenv` with `vitest` on `nextjs` app. While doing reverse engineering on `dotenv` to figure out what I am doing wrong, I stumbled on to this piece of code. Hope this fix will help a little.

Anyway, I did integrated `dotenv` with `vitest`. This change is not a blocker for me...