### PR TITLE
Fix weird freezing on import

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -311,4 +311,12 @@ module.exports.decrypt = DotenvModule.decrypt
 module.exports.parse = DotenvModule.parse
 module.exports.populate = DotenvModule.populate
 
-module.exports = DotenvModule
+module.exports = {
+  configDotenv,
+  _configVault,
+  _parseVault,
+  config,
+  decrypt,
+  parse,
+  populate
+}


### PR DESCRIPTION
Importing dotenv after registering swc / ts-node seems to freeze indefinitely (I suspect it's related to how its handled w/ es6) . This seems to resolve the issue. 