### PR TITLE
fix(lib): replace deprecated buf.slice() to buf. subarray()

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -237,9 +237,9 @@ function decrypt (encrypted, keyStr) {
   const key = Buffer.from(keyStr.slice(-64), 'hex')
   let ciphertext = Buffer.from(encrypted, 'base64')
 
-  const nonce = ciphertext.slice(0, 12)
-  const authTag = ciphertext.slice(-16)
-  ciphertext = ciphertext.slice(12, -16)
+  const nonce = ciphertext.subarray(0, 12)
+  const authTag = ciphertext.subarray(-16)
+  ciphertext = ciphertext.subarray(12, -16)
 
   try {
     const aesgcm = crypto.createDecipheriv('aes-256-gcm', key, nonce)


### PR DESCRIPTION
fix(lib): replace deprecated buf.slice() to buf. subarray()

The buf.slice() method in Buffer class is deprecated
in Node.js since `v16.15.0`.
Replace the deprecated `buf.slice()` method to `buf.subarray()`
in the `decrypt` function.

Refs: https://nodejs.org/api/buffer.html#bufslicestart-end