### PR TITLE
test duplication removal

### DIFF
--- a/tests/test-parse.js
+++ b/tests/test-parse.js
@@ -69,10 +69,6 @@ t.equal(parsed.EQUAL_SIGNS, 'equals==', 'respects equals signs in values')
 
 t.equal(parsed.RETAIN_INNER_QUOTES, '{"foo": "bar"}', 'retains inner quotes')
 
-t.equal(parsed.EQUAL_SIGNS, 'equals==', 'respects equals signs in values')
-
-t.equal(parsed.RETAIN_INNER_QUOTES, '{"foo": "bar"}', 'retains inner quotes')
-
 t.equal(parsed.RETAIN_INNER_QUOTES_AS_STRING, '{"foo": "bar"}', 'retains inner quotes')
 
 t.equal(parsed.RETAIN_INNER_QUOTES_AS_BACKTICKS, '{"foo": "bar\'s"}', 'retains inner quotes')


### PR DESCRIPTION
- **EQUAL_SIGNS** - [L68](https://github.com/motdotla/dotenv/blob/5d00dd9d1561059247eb31a2841cbc2e2b14f273/tests/test-parse.js#L68) duplicates with [L72](https://github.com/motdotla/dotenv/blob/5d00dd9d1561059247eb31a2841cbc2e2b14f273/tests/test-parse.js#L72)
- **RETAIN_INNER_QUOTES** - [L70](https://github.com/motdotla/dotenv/blob/5d00dd9d1561059247eb31a2841cbc2e2b14f273/tests/test-parse.js#L70) duplicates with [L74](https://github.com/motdotla/dotenv/blob/5d00dd9d1561059247eb31a2841cbc2e2b14f273/tests/test-parse.js#L74)