### PR TITLE
fix: Set NodeJS v14 as the oldest supported engine version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "typescript": "^4.8.4"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://dotenvx.com"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "typescript": "^4.8.4"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "browser": {
     "fs": false


### PR DESCRIPTION
dotenv v16.4.3 can't be used with Node 12 because the change introduced in the PR https://github.com/motdotla/dotenv/pull/805 contains an optional chaining operator that is supported by NodeJS starting from v14, thus running it with v12 engine version results in the
```
  if (options?.encoding) {
              ^
SyntaxError: Unexpected token '.'
```
exception.

Considering that Node v12 has reached EOL I assume it's better to set v14 as the oldest version constraint.