### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "dotenv",
   "version": "16.4.5",
   "description": "Loads environment variables from .env file",
-  "main": "lib/main.js",
   "types": "lib/main.d.ts",
   "exports": {
     ".": {


### PR DESCRIPTION
Removed "main" key.

The "exports" provides a modern alternative to "main" allowing multiple entry points to be defined, conditional entry resolution support between environments, and **preventing any other entry points besides those defined in "exports"**

If both ["exports"](https://nodejs.org/api/packages.html#exports) and ["main"](https://nodejs.org/api/packages.html#main) are defined, the ["exports"](https://nodejs.org/api/packages.html#exports) field takes precedence over ["main"](https://nodejs.org/api/packages.html#main) in supported versions of Node.js.