### PR TITLE
Use "node:" prefix everywhere.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x, 20.x]
+        node-version: [14.18.0, 14.x, 16.0.0, 16.x, 18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,7 +1,7 @@
-const fs = require('fs')
-const path = require('path')
-const os = require('os')
-const crypto = require('crypto')
+const fs = require('node:fs')
+const path = require('node:path')
+const os = require('node:os')
+const crypto = require('node:crypto')
 const packageJson = require('../package.json')
 
 const version = packageJson.version

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "typescript": "^4.8.4"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=14.18.0 <15 || >=16"
   },
   "browser": {
     "fs": false

--- a/tests/test-config-cli.js
+++ b/tests/test-config-cli.js
@@ -1,5 +1,5 @@
-const cp = require('child_process')
-const path = require('path')
+const cp = require('node:child_process')
+const path = require('node:path')
 
 const t = require('tap')
 

--- a/tests/test-config-vault.js
+++ b/tests/test-config-vault.js
@@ -1,5 +1,5 @@
-const fs = require('fs')
-const crypto = require('crypto')
+const fs = require('node:fs')
+const crypto = require('node:crypto')
 const sinon = require('sinon')
 const t = require('tap')
 

--- a/tests/test-config.js
+++ b/tests/test-config.js
@@ -1,6 +1,6 @@
-const fs = require('fs')
-const os = require('os')
-const path = require('path')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
 
 const sinon = require('sinon')
 const t = require('tap')

--- a/tests/test-parse-multiline.js
+++ b/tests/test-parse-multiline.js
@@ -1,4 +1,4 @@
-const fs = require('fs')
+const fs = require('node:fs')
 const t = require('tap')
 
 const dotenv = require('../lib/main')

--- a/tests/test-parse.js
+++ b/tests/test-parse.js
@@ -1,4 +1,4 @@
-const fs = require('fs')
+const fs = require('node:fs')
 const t = require('tap')
 
 const dotenv = require('../lib/main')

--- a/tests/test-populate.js
+++ b/tests/test-populate.js
@@ -1,4 +1,4 @@
-const fs = require('fs')
+const fs = require('node:fs')
 
 const sinon = require('sinon')
 const t = require('tap')


### PR DESCRIPTION
Updated the minimum nodejs version and CI accordingly.

---

The use of the "node:" prefix enables use in runtimes like `workerd` where compatibility layer is provided for "node:" improts only, but not for unprefixed packages. The cost to that is that the minimum nodejs version needs to be raised to ">=14.18.0 <15 || >=16".