### PR TITLE
fix: inline anchor groups

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -6,7 +6,7 @@ const packageJson = require('../package.json')
 
 const version = packageJson.version
 
-const LINE = /(?:^|^)\s*(?:export\s+)?([\w.-]+)(?:\s*=\s*?|:\s+?)(\s*'(?:\\'|[^'])*'|\s*"(?:\\"|[^"])*"|\s*`(?:\\`|[^`])*`|[^#\r\n]+)?\s*(?:#.*)?(?:$|$)/mg
+const LINE = /^\s*(?:export\s+)?([\w.-]+)(?:\s*=\s*?|:\s+?)(\s*'(?:\\'|[^'])*'|\s*"(?:\\"|[^"])*"|\s*`(?:\\`|[^`])*`|[^#\r\n]+)?\s*(?:#.*)?$/mg
 
 // Parse src into an Object
 function parse (src) {


### PR DESCRIPTION
Looks like https://github.com/motdotla/dotenv/commit/dbb50ee902820cc0a188ab7a60ea08645372b293 replaced `(?:^|\A)` with `(?:^|^)`, and similarly, `(?:$|\z)` with `(?:$|$)`.

These non-capturing groups are equivalent to the simple symbol they wrap.

I thought maybe you were trying to work around an eslint or regex linter bug, but `eslint-plugin-regexp` passes both the prior and this new RegExp pattern.

Thanks for building dotenv!