### PR TITLE
Improved logging so when debug is true print added key values

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -337,7 +337,7 @@ function populate (processEnv, parsed, options = {}) {
       }
     } else {
       processEnv[key] = parsed[key]
-      _debug(`"${key}" was added to process.env`)
+      _debug(`"${key}=${parsed[key]}" was added to process.env`)
     }
   }
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -325,6 +325,7 @@ function populate (processEnv, parsed, options = {}) {
     if (Object.prototype.hasOwnProperty.call(processEnv, key)) {
       if (override === true) {
         processEnv[key] = parsed[key]
+ 
       }
 
       if (debug) {
@@ -336,6 +337,7 @@ function populate (processEnv, parsed, options = {}) {
       }
     } else {
       processEnv[key] = parsed[key]
+      _debug(`"${key}" was added to process.env`)
     }
   }
 }


### PR DESCRIPTION
When debug is set to true a log statment will print out the value of  "${key}=${value}" was added to process.env