### PR TITLE
Add .tap to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,3 +14,4 @@ CONTRIBUTING.md
 dotenv.png
 dotenv.svg
 tea.yaml
+.tap/


### PR DESCRIPTION
Hi, this morning I was checking Renovate PRs and noticed that 16.4.6 mistakenly included a bunch of extra files, as I happened to click the [package diff from Renovate](https://app.renovatebot.com/package-diff?name=dotenv&from=16.4.5&to=16.4.6) to skim the readme change that was called out. Needless to say, the files in `.tap` folder stood out like as sore thumb. It seems to be for test results, code coverage and debug data from the last local run and that alone causes 16.4.6 to be 456% the size of 16.4.5, jumping up from 79.1 kB to 361 kB according to NPM. I'm assuming this was caused in 949b0eb3c7b80dc06d3b9fc4b46d6501c851c6d8 as that commit was updating the `tap` package and added `.tap` to `.gitignore`.

One could make the argument that it does not matter due to being a small absolute increase in size, but one could also say that with 40 million downloads weekly, the extra 24 kB in tarball size is an extra 915 GB of bandwidth per week with piles of wasted space when bundled into production copies of things. Myself? I just like clean diffs to see what changed.