### PR TITLE
Fix minor typo in README to indicate use is for env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ require('dotenv').config({ override: true })
 
 Default: `process.env`
 
-Specify an object to write your secrets to. Defaults to `process.env` environment variables.
+Specify an object to write your environment variables to. Defaults to `process.env` environment variables.
 
 ```js
 const myObject = {}


### PR DESCRIPTION
I reread this part of the README because I thought I may have missed something about this only being used for certain environment variables somehow marked as secrets, so I thought I'd make a small change to help clarify that this is not intended just for secrets.