### PR TITLE
docs: update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Dotenv is a zero-dependency module that loads environment variables from a `.env
 ## 🌱 Install
 
 ```bash
-npm install dotenv
+npm install dotenv --save
 ```
 
 You can also use an npm-compatible package manager like yarn or bun:

--- a/README.md
+++ b/README.md
@@ -58,11 +58,16 @@ Dotenv is a zero-dependency module that loads environment variables from a `.env
 ## 🌱 Install
 
 ```bash
-# install locally (recommended)
-npm install dotenv --save
+npm install dotenv
 ```
 
-Or installing with yarn? `yarn add dotenv`
+You can also use an npm-compatible package manager like yarn or bun:
+
+```bash
+yarn add dotenv
+# or
+bun add dotenv
+```
 
 ## 🏗️ Usage
 


### PR DESCRIPTION
Adds bun alongside yarn in the install instructions. Also, removes `--save` install command, since that's been the default for years (since npm v5)