### PR TITLE
chore(package): add homepage url

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "type": "git",
     "url": "git://github.com/motdotla/dotenv.git"
   },
+  "homepage": "https://github.com/motdotla/dotenv#readme",
   "funding": "https://dotenvx.com",
   "keywords": [
     "dotenv",


### PR DESCRIPTION
The addition of the [`homepage`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json?v=true#homepage) property allows for the URL to the repo to be correctly displayed when hovered over in `package.json` in VS Code when using a proxy/private registry like in Azure DevOps:

![Untitled](https://github.com/user-attachments/assets/6ffc2276-6830-49fa-97c5-f2e7e447fb8c)

Compared to something like eslint-plugin-regexp, which [does have the homepage set](https://github.com/ota-meshi/eslint-plugin-regexp/blob/2d90a1aca863508647115c76a7b0c23b493eb0e0/package.json#L60):

![image](https://github.com/user-attachments/assets/43f6f798-75dc-4d6d-bc00-df886a08a98d)

