### PR TITLE
feat: support nearest strategy to load .env from closest parent directory

### DIFF
--- a/lib/cli-options.js
+++ b/lib/cli-options.js
@@ -1,4 +1,4 @@
-const re = /^dotenv_config_(encoding|path|debug|override|DOTENV_KEY)=(.+)$/
+const re = /^dotenv_config_(encoding|path|debug|override|DOTENV_KEY|strategy)=(.+)$/
 
 module.exports = function optionMatcher (args) {
   return args.reduce(function (acc, cur) {

--- a/lib/env-options.js
+++ b/lib/env-options.js
@@ -21,4 +21,8 @@ if (process.env.DOTENV_CONFIG_DOTENV_KEY != null) {
   options.DOTENV_KEY = process.env.DOTENV_CONFIG_DOTENV_KEY
 }
 
+if (process.env.DOTENV_CONFIG_STRATEGY != null) {
+  options.strategy = process.env.DOTENV_CONFIG_STRATEGY
+}
+
 module.exports = options

--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -67,6 +67,15 @@ export interface DotenvConfigOptions {
   processEnv?: DotenvPopulateInput;
 
   /**
+   * Optional strategy to locate .env files from nearest parent directory upward.
+   *
+   * Default: `undefined`
+   *
+   * example: `require('dotenv').config({ strategy: 'nearest' })`
+   */
+  strategy?: 'nearest';
+
+  /**
    * Default: `undefined`
    *
    * Pass the DOTENV_KEY directly to config options. Defaults to looking for process.env.DOTENV_KEY environment variable. Note this only applies to decrypting .env.vault files. If passed as null or undefined, or not passed at all, dotenv falls back to its traditional job of parsing a .env file.

--- a/lib/main.js
+++ b/lib/main.js
@@ -8,6 +8,52 @@ const version = packageJson.version
 
 const LINE = /(?:^|^)\s*(?:export\s+)?([\w.-]+)(?:\s*=\s*?|:\s+?)(\s*'(?:\\'|[^'])*'|\s*"(?:\\"|[^"])*"|\s*`(?:\\`|[^`])*`|[^#\r\n]+)?\s*(?:#.*)?(?:$|$)/mg
 
+function findNearestEnvFile (startDir, debug = false) {
+  let dir = startDir
+  _debug(`dir: ${dir}`)
+
+  // Step 1: Search upward from current directory
+  while (true) {
+    const candidate = path.join(dir, '.env')
+    _debug(`candidate: ${candidate}`)
+    if (fs.existsSync(candidate)) {
+      if (debug) console.log(`[dotenv] Found nearest .env at: ${candidate}`)
+      return candidate
+    }
+
+    const parent = path.dirname(dir)
+    if (parent === dir) break // reached root
+    dir = parent
+  }
+
+  // Step 2: If not found above, search downward (one or two levels max)
+  function searchDownward (baseDir, depth = 0, maxDepth = 2) {
+    if (depth > maxDepth) return null
+
+    const files = fs.readdirSync(baseDir, { withFileTypes: true })
+
+    for (const file of files) {
+      const fullPath = path.join(baseDir, file.name)
+      if (file.isFile() && file.name === '.env') {
+        if (debug) console.log(`[dotenv] Found .env in child folder at: ${fullPath}`)
+        return fullPath
+      }
+      if (file.isDirectory()) {
+        const found = searchDownward(fullPath, depth + 1, maxDepth)
+        if (found) return found
+      }
+    }
+
+    return null
+  }
+
+  const downwardResult = searchDownward(startDir)
+  if (downwardResult) return downwardResult
+
+  if (debug) console.log('[dotenv] No .env file found using nearest strategy.')
+  return null
+}
+
 // Parse src into an Object
 function parse (src) {
   const obj = {}
@@ -202,7 +248,24 @@ function _configVault (options) {
 }
 
 function configDotenv (options) {
-  const dotenvPath = path.resolve(process.cwd(), '.env')
+  let dotenvPath = path.resolve(process.cwd(), '.env')
+
+  // NEW: If strategy is 'nearest', compute the path
+  if (options && options.strategy === 'nearest') {
+    _debug('inside dotenvPath')
+    dotenvPath = findNearestEnvFile(process.cwd(), options.debug)
+    _debug(`dotenvPath: ${dotenvPath}`)
+    if (!dotenvPath) {
+      if (options.debug) {
+        _warn('[dotenv][DEBUG] Failed to locate .env using nearest strategy.')
+      }
+      return { error: new Error('Could not find .env file using nearest strategy.') }
+    }
+    if (options.debug) {
+      _debug(`[dotenv][DEBUG] Using .env file at: ${dotenvPath}`)
+    }
+  }
+
   let encoding = 'utf8'
   const debug = Boolean(options && options.debug)
 
@@ -272,6 +335,21 @@ function config (options) {
     _warn(`You set DOTENV_KEY but you are missing a .env.vault file at ${vaultPath}. Did you forget to build it?`)
 
     return DotenvModule.configDotenv(options)
+  }
+
+  if (options && options.strategy === 'nearest') {
+    const nearestEnv = findNearestEnvFile()
+    if (nearestEnv) {
+      options.path = nearestEnv
+      if (options.debug) {
+        _debug(`[dotenv] Using nearest strategy. Found .env at: ${nearestEnv}`)
+      }
+    } else {
+      if (options.debug) {
+        _warn('[dotenv] No nearest .env file found in any direction.')
+      }
+      return { error: new Error('No nearest .env file found') }
+    }
   }
 
   return DotenvModule._configVault(options)

--- a/lib/main.js
+++ b/lib/main.js
@@ -10,14 +10,12 @@ const LINE = /(?:^|^)\s*(?:export\s+)?([\w.-]+)(?:\s*=\s*?|:\s+?)(\s*'(?:\\'|[^'
 
 function findNearestEnvFile (startDir, debug = false) {
   let dir = startDir
-  _debug(`dir: ${dir}`)
 
   // Step 1: Search upward from current directory
   while (true) {
     const candidate = path.join(dir, '.env')
-    _debug(`candidate: ${candidate}`)
     if (fs.existsSync(candidate)) {
-      if (debug) console.log(`[dotenv] Found nearest .env at: ${candidate}`)
+      if (debug) _debug(`found nearest .env at: ${candidate}`)
       return candidate
     }
 
@@ -252,17 +250,15 @@ function configDotenv (options) {
 
   // NEW: If strategy is 'nearest', compute the path
   if (options && options.strategy === 'nearest') {
-    _debug('inside dotenvPath')
     dotenvPath = findNearestEnvFile(process.cwd(), options.debug)
-    _debug(`dotenvPath: ${dotenvPath}`)
     if (!dotenvPath) {
       if (options.debug) {
-        _warn('[dotenv][DEBUG] Failed to locate .env using nearest strategy.')
+        _warn('failed to locate .env using nearest strategy.')
       }
       return { error: new Error('Could not find .env file using nearest strategy.') }
     }
     if (options.debug) {
-      _debug(`[dotenv][DEBUG] Using .env file at: ${dotenvPath}`)
+      _debug(`using .env file at: ${dotenvPath}`)
     }
   }
 
@@ -342,11 +338,11 @@ function config (options) {
     if (nearestEnv) {
       options.path = nearestEnv
       if (options.debug) {
-        _debug(`[dotenv] Using nearest strategy. Found .env at: ${nearestEnv}`)
+        _debug(`using nearest strategy. Found .env at: ${nearestEnv}`)
       }
     } else {
       if (options.debug) {
-        _warn('[dotenv] No nearest .env file found in any direction.')
+        _warn('no nearest .env file found in any direction.')
       }
       return { error: new Error('No nearest .env file found') }
     }

--- a/tests/.env
+++ b/tests/.env
@@ -36,3 +36,4 @@ RETAIN_INNER_QUOTES_AS_BACKTICKS=`{"foo": "bar's"}`
 TRIM_SPACE_FROM_UNQUOTED=    some spaced out string
 USERNAME=therealnerdybeast@example.tld
     SPACED_KEY = parsed
+TEST_KEY='Hello from root'

--- a/tests/fixtures/strategy-nearest/load-env-default-strategy.js
+++ b/tests/fixtures/strategy-nearest/load-env-default-strategy.js
@@ -1,0 +1,4 @@
+require('../../../lib/main').config()
+module.exports = function getEnv () {
+  return process.env.TEST_KEY
+}

--- a/tests/fixtures/strategy-nearest/load-env-nearest-strategy.js
+++ b/tests/fixtures/strategy-nearest/load-env-nearest-strategy.js
@@ -1,0 +1,4 @@
+require('../../../lib/main').config({ strategy: 'nearest' })
+module.exports = function getEnv () {
+  return process.env.TEST_KEY
+}

--- a/tests/fixtures/strategy-nearest/nested/load-env-default-strategy.js
+++ b/tests/fixtures/strategy-nearest/nested/load-env-default-strategy.js
@@ -1,0 +1,4 @@
+require('../../../../lib/main').config()
+module.exports = function getEnv () {
+  return process.env.TEST_KEY
+}

--- a/tests/fixtures/strategy-nearest/nested/load-env-nearest-strategy.js
+++ b/tests/fixtures/strategy-nearest/nested/load-env-nearest-strategy.js
@@ -1,0 +1,4 @@
+require('../../../../lib/main').config({ strategy: 'nearest' })
+module.exports = function getEnv () {
+  return process.env.TEST_KEY
+}

--- a/tests/test-load-env-strategy-default.js
+++ b/tests/test-load-env-strategy-default.js
@@ -1,0 +1,11 @@
+const t = require('tap')
+
+// load functions
+const getRootEnvByDefaultStrategy = require('./fixtures/strategy-nearest/load-env-default-strategy.js')
+const getNestedEnvByDefaultStrategy = require('./fixtures/strategy-nearest/nested/load-env-default-strategy.js')
+
+t.test('default config loads .env from current dir only', t => {
+  t.equal(getRootEnvByDefaultStrategy(), undefined, '.env doesnt loads as strategy is not mentioned')
+  t.equal(getNestedEnvByDefaultStrategy(), undefined, '.env doesnt loads as strategy is not mentioned')
+  t.end()
+})

--- a/tests/test-load-env-strategy-nearest.js
+++ b/tests/test-load-env-strategy-nearest.js
@@ -1,0 +1,11 @@
+const t = require('tap')
+
+// load functions
+const getRootEnvByNearestStrategy = require('./fixtures/strategy-nearest/load-env-nearest-strategy.js')
+const getNestedEnvByNearestStrategy = require('./fixtures/strategy-nearest/nested/load-env-nearest-strategy.js')
+
+t.test('default config loads .env from current dir only', t => {
+  t.equal(getRootEnvByNearestStrategy(), 'Hello from root', '.env loads from parent directory after strategy is mentioned')
+  t.equal(getNestedEnvByNearestStrategy(), 'Hello from root', '.env loads for nested files from parent directory after strategy is mentioned')
+  t.end()
+})


### PR DESCRIPTION
## What this PR does?

This PR adds support for a new config option: `{ strategy: 'nearest' }`  
When enabled, dotenv will look for the nearest `.env` file starting from `process.cwd()` and walking up the directory tree.  
This helps when working in monorepos or nested folder structures where multiple `.env` files might exist.

## Related Issue
Closes #866 

## Why it's useful

- Useful in monorepos where each package can have its own `.env`
- Prevents loading the wrong .env from the root when running scripts from a subfolder
- Backward-compatible: the default strategy remains unchanged if no config is passed

## How it works

- Added an optional `strategy: 'nearest'` to the config
- If strategy is set to 'nearest', the loader walks up from `process.cwd()` until it finds a `.env`
- If not found, behaves same as before

## Tests added

- Fixtures with nested folders and multiple .env files
- Tests for both default and 'nearest' strategy behavior

## Example usage

```js
require('dotenv').config({ strategy: 'nearest' })
```