### PR TITLE
fix: return first valid path in _vaultPath when array is provided

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -156,24 +156,25 @@ function _instructions (result, dotenvKey) {
 }
 
 function _vaultPath (options) {
-  let possibleVaultPath = null
-
   if (options && options.path && options.path.length > 0) {
     if (Array.isArray(options.path)) {
       for (const filepath of options.path) {
-        if (fs.existsSync(filepath)) {
-          possibleVaultPath = filepath.endsWith('.vault') ? filepath : `${filepath}.vault`
+        const fullPath = filepath.endsWith('.vault') ? filepath : `${filepath}.vault`
+        if (fs.existsSync(fullPath)) {
+          return fullPath // Return first valid path
         }
       }
     } else {
-      possibleVaultPath = options.path.endsWith('.vault') ? options.path : `${options.path}.vault`
+      const fullPath = options.path.endsWith('.vault') ? options.path : `${options.path}.vault`
+      if (fs.existsSync(fullPath)) {
+        return fullPath
+      }
     }
   } else {
-    possibleVaultPath = path.resolve(process.cwd(), '.env.vault')
-  }
-
-  if (fs.existsSync(possibleVaultPath)) {
-    return possibleVaultPath
+    const defaultPath = path.resolve(process.cwd(), '.env.vault')
+    if (fs.existsSync(defaultPath)) {
+      return defaultPath
+    }
   }
 
   return null
@@ -343,6 +344,7 @@ const DotenvModule = {
   configDotenv,
   _configVault,
   _parseVault,
+  _vaultPath,
   config,
   decrypt,
   parse,
@@ -352,6 +354,7 @@ const DotenvModule = {
 module.exports.configDotenv = DotenvModule.configDotenv
 module.exports._configVault = DotenvModule._configVault
 module.exports._parseVault = DotenvModule._parseVault
+module.exports._vaultPath = _vaultPath
 module.exports.config = DotenvModule.config
 module.exports.decrypt = DotenvModule.decrypt
 module.exports.parse = DotenvModule.parse

--- a/tests/test-vault-path.js
+++ b/tests/test-vault-path.js
@@ -1,0 +1,25 @@
+const t = require('tap')
+const fs = require('fs')
+const path = require('path')
+const { _vaultPath } = require('../lib/main')
+
+const testDir = path.join(__dirname, 'envtest')
+const fakePath = path.join(testDir, '.fake.env')
+const validPath = path.join(testDir, '.real.env.vault')
+
+// Setup
+if (!fs.existsSync(testDir)) {
+  fs.mkdirSync(testDir)
+}
+fs.writeFileSync(validPath, 'DOTENV_VAULT_PRODUCTION="fake"')
+
+// Should return the first existing vault path
+t.equal(
+  _vaultPath({ path: [fakePath, path.join(testDir, '.real.env')] }),
+  validPath,
+  'returns first matching .env.vault path from array'
+)
+
+// Teardown
+fs.unlinkSync(validPath)
+fs.rmdirSync(testDir)


### PR DESCRIPTION
### 🔍 What This PR Does

This PR fixes a logic issue in the `_vaultPath()` function, which previously returned the **last valid match** from an array of paths in `options.path`, even if earlier paths were valid.

### ✅ Expected Behavior

Return the **first** existing `.env.vault` path when an array of paths is provided.

---

### 🔧 Summary of Changes

- Updated `_vaultPath` to return early on first valid path in array  
- Cleaned up unnecessary control flow in the function  
- Exported `_vaultPath` from `main.js` for testing  
- Added new test file: `tests/test-vault-path.js` to verify the fix  
- Ensured compliance with StandardJS linting rules  

---

### 🧪 Test Coverage

```yaml
npm test ✅ All tests pass
npm run lint ✅ Linting clean
```

---

### 🙌 Why It Matters

This makes behavior predictable and respects the order in which the user specifies fallback `.env` paths. It's a safer, more intuitive approach when supporting multiple environments.

Let me know if any updates are needed — happy to iterate!