### PR TITLE
Set `quiet` to `true` by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ require('dotenv').config({ path: ['.env.local', '.env'] })
 
 ##### quiet
 
-Default: `false`
+Default: `true`
 
 Suppress runtime logging message.
 

--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -40,7 +40,7 @@ export interface DotenvConfigOptions {
   encoding?: string;
 
   /**
-   * Default: `false`
+   * Default: `true`
    *
    * Suppress all output (except errors).
    *

--- a/lib/main.js
+++ b/lib/main.js
@@ -190,7 +190,7 @@ function _resolveHome (envPath) {
 
 function _configVault (options) {
   const debug = Boolean(options && options.debug)
-  const quiet = Boolean(options && options.quiet)
+  const quiet = options && 'quiet' in options ? options.quiet : true
 
   if (debug || !quiet) {
     _log('Loading env from encrypted .env.vault')
@@ -212,7 +212,7 @@ function configDotenv (options) {
   const dotenvPath = path.resolve(process.cwd(), '.env')
   let encoding = 'utf8'
   const debug = Boolean(options && options.debug)
-  const quiet = Boolean(options && options.quiet)
+  const quiet = options && 'quiet' in options ? options.quiet : true
 
   if (options && options.encoding) {
     encoding = options.encoding

--- a/lib/main.js
+++ b/lib/main.js
@@ -91,11 +91,11 @@ function _parseVault (options) {
 }
 
 function _warn (message) {
-  console.error(`[dotenv@${version}][WARN] ${message}`)
+  console.warn(`[dotenv@${version}][WARN] ${message}`)
 }
 
 function _debug (message) {
-  console.log(`[dotenv@${version}][DEBUG] ${message}`)
+  console.debug(`[dotenv@${version}][DEBUG] ${message}`)
 }
 
 function _log (message) {

--- a/tests/test-config-vault.js
+++ b/tests/test-config-vault.js
@@ -28,19 +28,19 @@ t.afterEach(() => {
 t.test('logs when no path is set', ct => {
   ct.plan(1)
 
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'warn')
 
   dotenv.config()
   ct.ok(logStub.called)
 })
 
-t.test('does log by default', ct => {
+t.test('does not log by default', ct => {
   ct.plan(1)
 
   logStub = sinon.stub(console, 'log')
 
   dotenv.config({ path: testPath })
-  ct.ok(logStub.called)
+  ct.ok(logStub.notCalled)
 })
 
 t.test('does not log if quiet flag passed true', ct => {
@@ -79,13 +79,13 @@ t.test('logs if debug set', ct => {
   ct.ok(logStub.called)
 })
 
-t.test('does log when testPath calls to .env.vault directly (interpret what the user meant)', ct => {
+t.test('does not log when testPath calls to .env.vault directly (interpret what the user meant)', ct => {
   ct.plan(1)
 
   logStub = sinon.stub(console, 'log')
 
   dotenv.config({ path: `${testPath}.vault` })
-  ct.ok(logStub.called)
+  ct.ok(logStub.notCalled)
 })
 
 t.test('logs when testPath calls to .env.vault directly (interpret what the user meant) and debug true', ct => {
@@ -100,7 +100,7 @@ t.test('logs when testPath calls to .env.vault directly (interpret what the user
 t.test('warns if DOTENV_KEY exists but .env.vault does not exist', ct => {
   ct.plan(1)
 
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'warn')
 
   const existsSync = sinon.stub(fs, 'existsSync').returns(false) // make .env.vault not exist
   dotenv.config({ path: testPath })
@@ -113,7 +113,7 @@ t.test('warns if DOTENV_KEY exists but .env.vault does not exist', ct => {
 t.test('warns if DOTENV_KEY exists but .env.vault does not exist (set as array)', ct => {
   ct.plan(1)
 
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'warn')
 
   const existsSync = sinon.stub(fs, 'existsSync').returns(false) // make .env.vault not exist
   dotenv.config({ path: [testPath] })

--- a/tests/test-config.js
+++ b/tests/test-config.js
@@ -252,7 +252,7 @@ t.test('logs any errors parsing when in debug and override mode', ct => {
 })
 
 t.test('deals with file:// path', ct => {
-  const logStub = sinon.stub(console, 'log')
+  const logStub = sinon.stub(console, 'warn')
 
   const testPath = 'file:///tests/.env'
   const env = dotenv.config({ path: testPath })
@@ -261,7 +261,7 @@ t.test('deals with file:// path', ct => {
   ct.equal(process.env.BASIC, undefined)
   ct.equal(env.error.message, "ENOENT: no such file or directory, open 'file:///tests/.env'")
 
-  ct.ok(logStub.called)
+  ct.ok(logStub.notCalled)
 
   logStub.restore()
 

--- a/tests/test-populate.js
+++ b/tests/test-populate.js
@@ -59,7 +59,7 @@ t.test('does write over keys already in processEnv if override turned on', ct =>
 t.test('logs any errors populating when in debug mode but override turned off', ct => {
   ct.plan(2)
 
-  const logStub = sinon.stub(console, 'log')
+  const logStub = sinon.stub(console, 'debug')
 
   const parsed = { test: false }
   process.env.test = true


### PR DESCRIPTION
## This pull request introduces the following changes:
1. Sets the `quiet` option to `true` by default.
2. Replaces `console.error`/`console.log` in the `_warn` and `_debug` functions with `console.warn` and `console.debug`, respectively, to better align with appropriate logging levels.
3. Updates related tests.

## Reason
- Closes #876
- Using `console.warn` and `console.debug` provides a more accurate reflection of logging semantics.

## All tests **PASSED**
<details>
<summary>View `npm test` output (Ubuntu 24.04.2 LTS, kernel 6.8.0-60-generic)</summary>
> dotenv@17.0.0 pretest
> npm run lint && npm run dts-check


> dotenv@17.0.0 lint
> standard


> dotenv@17.0.0 dts-check
> tsc --project tests/types/tsconfig.json


> dotenv@17.0.0 test
> tap run --allow-empty-coverage --disable-coverage --timeout=60000

 PASS  tests/test-cli-options.js 6 OK 7.257s

1> tests/test-config-vault.js
[dotenv@17.0.0][DEBUG] No encoding is specified. UTF-8 is used by default
[dotenv@17.0.0][DEBUG] "DOTENV_VAULT_DEVELOPMENT" is already defined and was NOT overwritten
[dotenv@17.0.0][DEBUG] "ALPHA" is already defined and was NOT overwritten
[dotenv@17.0.0][DEBUG] No encoding is specified. UTF-8 is used by default
[dotenv@17.0.0][DEBUG] "DOTENV_VAULT_DEVELOPMENT" is already defined and was NOT overwritten
[dotenv@17.0.0][DEBUG] "ALPHA" is already defined and was NOT overwritten
[dotenv@17.0.0][DEBUG] No encoding is specified. UTF-8 is used by default
[dotenv@17.0.0][DEBUG] "DOTENV_VAULT_DEVELOPMENT" is already defined and WAS overwritten
[dotenv@17.0.0][DEBUG] "ALPHA" is already defined and WAS overwritten
[dotenv@17.0.0][DEBUG] No encoding is specified. UTF-8 is used by default
[dotenv@17.0.0][DEBUG] "DOTENV_VAULT_DEVELOPMENT" is already defined and was NOT overwritten
[dotenv@17.0.0][DEBUG] "ALPHA" is already defined and was NOT overwritten

 PASS  tests/test-config-vault.js 45 OK 8.082s
 PASS  tests/test-config-cli.js 3 OK 11s

1> tests/test-config.js
[dotenv@17.0.0][DEBUG] No encoding is specified. UTF-8 is used by default
[dotenv@17.0.0][DEBUG] Failed to load /home/sefinek/dotenv/.env ENOENT: no such file or directory, open
'/home/sefinek/dotenv/.env'
logging other
[dotenv@17.0.0][DEBUG] No encoding is specified. UTF-8 is used by default
[dotenv@17.0.0][DEBUG] Failed to load /home/sefinek/dotenv/.env Error
[dotenv@17.0.0][DEBUG] No encoding is specified. UTF-8 is used by default
[dotenv@17.0.0][DEBUG] Failed to load /home/sefinek/dotenv/.env ENOENT: no such file or directory, open
'/home/sefinek/dotenv/.env'
[dotenv@17.0.0][DEBUG] No encoding is specified. UTF-8 is used by default
[dotenv@17.0.0][DEBUG] Failed to load file:///tests/.env ENOENT: no such file or directory, open 'file:///tests/.env'
[dotenv@17.0.0][DEBUG] No encoding is specified. UTF-8 is used by default
[dotenv@17.0.0][DEBUG] Failed to load file:///tests/.env ENOENT: no such file or directory, open 'file:///tests/.env'
[dotenv@17.0.0][DEBUG] Failed to load file:///tests/.env fail

 PASS  tests/test-config.js 51 OK 6.814s
 PASS  tests/test-decrypt.js 1 OK 6.440s
 PASS  tests/test-env-options.js 7 OK 5.833s
 PASS  tests/test-parse-multiline.js 26 OK 5.739s
 PASS  tests/test-parse.js 41 OK 6.228s

1> tests/test-populate.js
[dotenv@17.0.0][DEBUG] "test" is already defined and WAS overwritten

 PASS  tests/test-populate.js 7 OK 5.833s

1> tests/types/test.ts
[dotenv@17.0.0][DEBUG] Failed to load .env-example ENOENT: no such file or directory, open '.env-example'
[dotenv@17.0.0] injecting env (0) from .env-example – 🔐 encrypt with dotenvx: https://dotenvx.com

 SKIP  tests/types/test.ts 0 OK 3.855s
 ~ no tests found


  🌈 TEST COMPLETE 🌈


Asserts:  187 pass  0 fail  1 skip  187 of 188 complete
Suites:     9 pass  0 fail  1 skip     9 of 10 complete

# No coverage generated
# { total: 188, pass: 187, skip: 1 }
# time=24491.419ms
</details>

## Example
### index.js
```js
require('dotenv').config();
console.log(process.env.HELLO);
```
### .env
```env
HELLO="Hello World!"
```
### Output
```text
> node .
Hello World!
```