### PR TITLE
fix: make DotenvPopulateInput accept NodeJS.ProcessEnv type

### DIFF
--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -124,7 +124,7 @@ export interface DotenvPopulateOptions {
 }
 
 export interface DotenvPopulateInput {
-  [name: string]: string;
+  [name: string]: string | undefined;
 }
 
 /**

--- a/tests/types/test.ts
+++ b/tests/types/test.ts
@@ -17,3 +17,8 @@ const dbHost: string = parsed["DB_HOST"];
 
 const parsedFromBuffer = parse(Buffer.from("JUSTICE=league\n"));
 const justice: string = parsedFromBuffer["JUSTICE"];
+
+config({
+  // make sure the type accepts process.env (it didn't in the past)
+  processEnv: process.env,
+});


### PR DESCRIPTION
fix #767 