### PR TITLE
Add explicit test for duplicate keys in parse (last value wins)

### DIFF
--- a/tests/test-parse.js
+++ b/tests/test-parse.js
@@ -82,6 +82,9 @@ t.equal(parsed.SPACED_KEY, 'parsed', 'parses keys and values surrounded by space
 const payload = dotenv.parse(Buffer.from('BUFFER=true'))
 t.equal(payload.BUFFER, 'true', 'should parse a buffer into an object')
 
+const duplicate = dotenv.parse(Buffer.from('DUP=one\nDUP=two'))
+t.equal(duplicate.DUP, 'two', 'last duplicate key wins')
+
 const expectedPayload = { SERVER: 'localhost', PASSWORD: 'password', DB: 'tests' }
 
 const RPayload = dotenv.parse(Buffer.from('SERVER=localhost\rPASSWORD=password\rDB=tests\r'))


### PR DESCRIPTION
Adds an explicit test to document behavior when duplicate keys
appear within a single .env file. Currently, the last occurrence
wins due to object assignment order. This test formalizes that
behavior as part of the parse contract.