### PR TITLE
feat: Add a script to generate `env.d.ts` for TypeScript type safety of environment variables, along with its tests and project documentation.

### DIFF
--- a/lib/env-type-generator.js
+++ b/lib/env-type-generator.js
@@ -1,0 +1,34 @@
+const fs = require('fs')
+const path = require('path')
+const DotenvModule = require('./main')
+
+const DEFAULT_ENV_FILENAME = '.env'
+const DEFAULT_OUTPUT_FILENAME = 'env.d.ts'
+
+function generate (options) {
+  const envPath = options?.path || path.resolve(process.cwd(), DEFAULT_ENV_FILENAME)
+  const outputPath = options?.output || path.resolve(process.cwd(), DEFAULT_OUTPUT_FILENAME)
+
+  if (!fs.existsSync(envPath)) {
+    throw new Error(`File not found: ${envPath}`)
+  }
+
+  const parsed = DotenvModule.parse(fs.readFileSync(envPath))
+  const keys = Object.keys(parsed)
+
+  const content = `declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+${keys.map(key => `      ${key}: string;`).join('\n')}
+    }
+  }
+}
+
+export {}
+`
+
+  fs.writeFileSync(outputPath, content)
+  return content
+}
+
+module.exports = generate

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "test": "tap run tests/**/*.js --allow-empty-coverage --disable-coverage --timeout=60000",
     "test:coverage": "tap run tests/**/*.js --show-full-coverage --timeout=60000 --coverage-report=text --coverage-report=lcov",
     "prerelease": "npm test",
-    "release": "standard-version"
+    "release": "standard-version",
+    "generate-types": "node -e \"require('./lib/env-type-generator')()\""
   },
   "repository": {
     "type": "git",

--- a/tests/test-env-type-generator.js
+++ b/tests/test-env-type-generator.js
@@ -1,0 +1,28 @@
+const fs = require('fs')
+const path = require('path')
+const generate = require('../lib/env-type-generator')
+const tap = require('tap')
+
+const TEST_ENV_FILE = path.resolve(__dirname, '.env.test.gen')
+const TEST_OUTPUT_FILE = path.resolve(__dirname, 'env.test.d.ts')
+
+tap.test('generate types', (t) => {
+  // Setup
+  fs.writeFileSync(TEST_ENV_FILE, 'TEST_VAR=hello\nANOTHER_VAR=world')
+
+  // Execute
+  generate({ path: TEST_ENV_FILE, output: TEST_OUTPUT_FILE })
+
+  // Verify
+  const content = fs.readFileSync(TEST_OUTPUT_FILE, 'utf8')
+  t.ok(content.includes('TEST_VAR: string;'), 'contains TEST_VAR')
+  t.ok(content.includes('ANOTHER_VAR: string;'), 'contains ANOTHER_VAR')
+  t.ok(content.includes('namespace NodeJS'), 'contains namespace NodeJS')
+  t.ok(content.includes('interface ProcessEnv'), 'contains interface ProcessEnv')
+
+  // Cleanup
+  fs.unlinkSync(TEST_ENV_FILE)
+  fs.unlinkSync(TEST_OUTPUT_FILE)
+
+  t.end()
+})


### PR DESCRIPTION
Added lib/env-type-generator.js, a utility that:

- Reads a .env file

- Parses all environment variable keys

- Generates an env.d.ts file that augments NodeJS.ProcessEnv with the actual variable names

This provides full TypeScript autocompletion and compile-time validation for environment variables.

---