### PR TITLE
fix: route _log/_debug to stderr, simplify LINE regex, add troubleshooting docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,48 @@ Alternatively, just use [dotenv-webpack](https://github.com/mrsteele/dotenv-webp
 
 &nbsp;
 
+## Troubleshooting
+
+<details><summary>My environment variable is not being updated — it already exists in my shell</summary><br/>
+
+By design, dotenv **never overwrites** a variable that already exists in `process.env`. This prevents accidental overrides of variables set by your CI/CD system, Docker environment, or shell profile.
+
+**Why?** If you have `PORT=3000` set in your shell and `PORT=8080` in your `.env` file, your app will see `PORT=3000`. This matches The Twelve-Factor App recommendation that the environment always wins.
+
+To deliberately override existing variables, use the `override` option:
+
+```js
+require('dotenv').config({ override: true })
+```
+
+Or with the preload flag:
+
+```bash
+DOTENV_CONFIG_OVERRIDE=true node -r dotenv/config your_script.js
+```
+
+> **Tip:** On Windows, system variables like `USERNAME`, `COMPUTERNAME`, and `PATH` are pre-set and will **not** be overwritten unless `override: true` is used.
+
+</details>
+<details><summary>My `.env` file is not loading — variables are undefined</summary><br/>
+
+Enable debug mode to get detailed output about what dotenv is doing:
+
+```js
+require('dotenv').config({ debug: true })
+```
+
+Common causes:
+- **Wrong working directory** — dotenv looks for `.env` relative to `process.cwd()`. Make sure you run your app from the project root.
+- **Typo in file name** — the file must be named `.env` (with a leading dot), not `env` or `.env.txt`.
+- **Incorrect path option** — if using a custom path, double-check it resolves correctly.
+
+Use `{ path: '/absolute/path/to/.env' }` to specify an exact location.
+
+</details>
+
+&nbsp;
+
 ## Docs
 
 Dotenv exposes four functions:

--- a/lib/main.js
+++ b/lib/main.js
@@ -43,7 +43,7 @@ function dim (text) {
   return supportsAnsi() ? `\x1b[2m${text}\x1b[0m` : text
 }
 
-const LINE = /(?:^|^)\s*(?:export\s+)?([\w.-]+)(?:\s*=\s*?|:\s+?)(\s*'(?:\\'|[^'])*'|\s*"(?:\\"|[^"])*"|\s*`(?:\\`|[^`])*`|[^#\r\n]+)?\s*(?:#.*)?(?:$|$)/mg
+const LINE = /^\s*(?:export\s+)?([\w.-]+)(?:\s*=\s*?|:\s+?)(\s*'(?:\\'|[^'])*'|\s*"(?:\\"|[^"])*"|\s*`(?:\\`|[^`])*`|[^#\r\n]+)?\s*(?:#.*)?$/mg
 
 // Parse src into an Object
 function parse (src) {
@@ -132,11 +132,11 @@ function _warn (message) {
 }
 
 function _debug (message) {
-  console.log(`[dotenv@${version}][DEBUG] ${message}`)
+  console.error(`[dotenv@${version}][DEBUG] ${message}`)
 }
 
 function _log (message) {
-  console.log(`[dotenv@${version}] ${message}`)
+  console.error(`[dotenv@${version}] ${message}`)
 }
 
 function _dotenvKey (options) {

--- a/tests/test-config-vault.js
+++ b/tests/test-config-vault.js
@@ -28,7 +28,7 @@ t.afterEach(() => {
 t.test('does log when testPath calls to .env.vault directly (interpret what the user meant)', ct => {
   ct.plan(1)
 
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   dotenv.config({ path: `${testPath}.vault` })
   ct.ok(logStub.called)
@@ -38,7 +38,7 @@ t.test('warns if DOTENV_KEY exists but .env.vault does not exist', ct => {
   ct.plan(1)
 
   const testPath = 'tests/.env'
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   const existsSync = sinon.stub(fs, 'existsSync').returns(false) // make .env.vault not exist
   dotenv.config({ path: testPath })
@@ -52,7 +52,7 @@ t.test('warns if DOTENV_KEY exists but .env.vault does not exist (set as array)'
   ct.plan(1)
 
   const testPath = 'tests/.env'
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   const existsSync = sinon.stub(fs, 'existsSync').returns(false) // make .env.vault not exist
   dotenv.config({ path: [testPath] })
@@ -65,7 +65,7 @@ t.test('warns if DOTENV_KEY exists but .env.vault does not exist (set as array)'
 t.test('logs when testPath calls to .env.vault directly (interpret what the user meant) and debug true', ct => {
   ct.plan(1)
 
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   dotenv.config({ path: `${testPath}.vault`, debug: true })
   ct.ok(logStub.called)
@@ -260,7 +260,7 @@ t.test('can write to a different object rather than process.env', ct => {
 
   process.env.ALPHA = 'other' // reset process.env
 
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   const myObject = {}
 
@@ -273,7 +273,7 @@ t.test('can write to a different object rather than process.env', ct => {
 t.test('logs when debug and override are turned on', ct => {
   ct.plan(1)
 
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   dotenv.config({ path: testPath, override: true, debug: true })
 
@@ -283,7 +283,7 @@ t.test('logs when debug and override are turned on', ct => {
 t.test('logs when debug is on and override is false', ct => {
   ct.plan(1)
 
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   dotenv.config({ path: testPath, override: false, debug: true })
 

--- a/tests/test-config.js
+++ b/tests/test-config.js
@@ -120,7 +120,7 @@ t.test('takes option for encoding', ct => {
 })
 
 t.test('takes option for debug', ct => {
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   dotenv.config({ debug: 'true' })
   ct.ok(logStub.called)
@@ -231,7 +231,7 @@ t.test('returns any errors thrown from reading file or parsing', ct => {
 t.test('logs any errors thrown from reading file or parsing when in debug mode', ct => {
   ct.plan(2)
 
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
   const readFileSyncStub = sinon.stub(fs, 'readFileSync').returns('test=foo')
 
   readFileSyncStub.throws()
@@ -246,7 +246,7 @@ t.test('logs any errors thrown from reading file or parsing when in debug mode',
 t.test('logs any errors parsing when in debug and override mode', ct => {
   ct.plan(1)
 
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   dotenv.config({ debug: true, override: true })
 
@@ -254,7 +254,7 @@ t.test('logs any errors parsing when in debug and override mode', ct => {
 })
 
 t.test('deals with file:// path', ct => {
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   const testPath = 'file:///tests/.env'
   const env = dotenv.config({ path: testPath })
@@ -269,7 +269,7 @@ t.test('deals with file:// path', ct => {
 })
 
 t.test('deals with file:// path and debug true', ct => {
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   const testPath = 'file:///tests/.env'
   const env = dotenv.config({ path: testPath, debug: true })
@@ -284,7 +284,7 @@ t.test('deals with file:// path and debug true', ct => {
 })
 
 t.test('path.relative fails somehow', ct => {
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
   const pathRelativeStub = sinon.stub(path, 'relative').throws(new Error('fail'))
 
   const testPath = 'file:///tests/.env'
@@ -307,7 +307,7 @@ t.test('displays random tips from the tips array', ct => {
   const originalTTY = process.stdout.isTTY
   process.stdout.isTTY = true
 
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
   const testPath = 'tests/.env'
 
   // Test that tips are displayed (run config multiple times to see variation)
@@ -368,7 +368,7 @@ t.test('displays random tips from the tips array with fallback for isTTY false',
   const originalTTY = process.stdout.isTTY
   process.stdout.isTTY = undefined
 
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
   const testPath = 'tests/.env'
 
   // Test that tips are displayed (run config multiple times to see variation)
@@ -426,7 +426,7 @@ t.test('displays random tips from the tips array with fallback for isTTY false',
 t.test('logs when no path is set', ct => {
   ct.plan(1)
 
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   dotenv.config()
   ct.ok(logStub.called)
@@ -436,7 +436,7 @@ t.test('does log by default', ct => {
   ct.plan(1)
 
   const testPath = 'tests/.env'
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   dotenv.config({ path: testPath })
   ct.ok(logStub.called)
@@ -446,7 +446,7 @@ t.test('does not log if quiet flag passed true', ct => {
   ct.plan(1)
 
   const testPath = 'tests/.env'
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   dotenv.config({ path: testPath, quiet: true })
   ct.ok(logStub.notCalled)
@@ -457,7 +457,7 @@ t.test('does not log if process.env.DOTENV_CONFIG_QUIET is true', ct => {
 
   process.env.DOTENV_CONFIG_QUIET = 'true'
   const testPath = 'tests/.env'
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   dotenv.config({ path: testPath })
   ct.ok(logStub.notCalled)
@@ -468,7 +468,7 @@ t.test('does log if quiet flag false', ct => {
   ct.plan(1)
 
   const testPath = 'tests/.env'
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   dotenv.config({ path: testPath, quiet: false })
   ct.ok(logStub.called)
@@ -479,7 +479,7 @@ t.test('does log if process.env.DOTENV_CONFIG_QUIET is false', ct => {
 
   process.env.DOTENV_CONFIG_QUIET = 'false'
   const testPath = 'tests/.env'
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   dotenv.config({ path: testPath })
   ct.ok(logStub.called)
@@ -490,7 +490,7 @@ t.test('does log if quiet flag present and undefined/null', ct => {
   ct.plan(1)
 
   const testPath = 'tests/.env'
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   dotenv.config({ path: testPath, quiet: undefined })
   ct.ok(logStub.called)
@@ -500,7 +500,7 @@ t.test('logs if debug set', ct => {
   ct.plan(1)
 
   const testPath = 'tests/.env'
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   dotenv.config({ path: testPath, debug: true })
   ct.ok(logStub.called)

--- a/tests/test-populate.js
+++ b/tests/test-populate.js
@@ -59,7 +59,7 @@ t.test('does write over keys already in processEnv if override turned on', ct =>
 t.test('logs any errors populating when in debug mode but override turned off', ct => {
   ct.plan(2)
 
-  const logStub = sinon.stub(console, 'log')
+  const logStub = sinon.stub(console, 'error')
 
   const parsed = { test: false }
   process.env.test = true
@@ -75,7 +75,7 @@ t.test('logs any errors populating when in debug mode but override turned off', 
 t.test('logs populating when debug mode and override turned on', ct => {
   ct.plan(1)
 
-  const logStub = sinon.stub(console, 'log')
+  const logStub = sinon.stub(console, 'error')
 
   const parsed = { test: false }
   process.env.test = true


### PR DESCRIPTION
## Summary

This PR addresses three independent improvements to the dotenv codebase.

---

### Fix 1: Route [_log](cci:1://file:///Users/sudipkumarprasad/Desktop/dotenv/lib/main.js:137:0-139:1) and [_debug](cci:1://file:///Users/sudipkumarprasad/Desktop/dotenv/lib/main.js:133:0-135:1) output to `stderr`

**Problem:** [_log()](cci:1://file:///Users/sudipkumarprasad/Desktop/dotenv/lib/main.js:137:0-139:1) and [_debug()](cci:1://file:///Users/sudipkumarprasad/Desktop/dotenv/lib/main.js:133:0-135:1) both used `console.log`, which writes to `stdout`. This causes diagnostic/status messages to pollute the standard output stream, breaking common shell patterns like:

```sh
node app.js | jq         # dotenv tip messages get mixed into the JSON stream
node app.js > output.txt # log messages end up written to the file
