### PR TITLE
fix: write log and debug output to stderr instead of stdout

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -132,11 +132,11 @@ function _warn (message) {
 }
 
 function _debug (message) {
-  console.log(`[dotenv@${version}][DEBUG] ${message}`)
+  console.error(`[dotenv@${version}][DEBUG] ${message}`)
 }
 
 function _log (message) {
-  console.log(`[dotenv@${version}] ${message}`)
+  console.error(`[dotenv@${version}] ${message}`)
 }
 
 function _dotenvKey (options) {

--- a/tests/test-config-vault.js
+++ b/tests/test-config-vault.js
@@ -28,7 +28,7 @@ t.afterEach(() => {
 t.test('does log when testPath calls to .env.vault directly (interpret what the user meant)', ct => {
   ct.plan(1)
 
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   dotenv.config({ path: `${testPath}.vault` })
   ct.ok(logStub.called)
@@ -38,7 +38,7 @@ t.test('warns if DOTENV_KEY exists but .env.vault does not exist', ct => {
   ct.plan(1)
 
   const testPath = 'tests/.env'
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   const existsSync = sinon.stub(fs, 'existsSync').returns(false) // make .env.vault not exist
   dotenv.config({ path: testPath })
@@ -52,7 +52,7 @@ t.test('warns if DOTENV_KEY exists but .env.vault does not exist (set as array)'
   ct.plan(1)
 
   const testPath = 'tests/.env'
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   const existsSync = sinon.stub(fs, 'existsSync').returns(false) // make .env.vault not exist
   dotenv.config({ path: [testPath] })
@@ -65,7 +65,7 @@ t.test('warns if DOTENV_KEY exists but .env.vault does not exist (set as array)'
 t.test('logs when testPath calls to .env.vault directly (interpret what the user meant) and debug true', ct => {
   ct.plan(1)
 
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   dotenv.config({ path: `${testPath}.vault`, debug: true })
   ct.ok(logStub.called)
@@ -260,7 +260,7 @@ t.test('can write to a different object rather than process.env', ct => {
 
   process.env.ALPHA = 'other' // reset process.env
 
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   const myObject = {}
 
@@ -273,7 +273,7 @@ t.test('can write to a different object rather than process.env', ct => {
 t.test('logs when debug and override are turned on', ct => {
   ct.plan(1)
 
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   dotenv.config({ path: testPath, override: true, debug: true })
 
@@ -283,7 +283,7 @@ t.test('logs when debug and override are turned on', ct => {
 t.test('logs when debug is on and override is false', ct => {
   ct.plan(1)
 
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   dotenv.config({ path: testPath, override: false, debug: true })
 

--- a/tests/test-config.js
+++ b/tests/test-config.js
@@ -120,7 +120,7 @@ t.test('takes option for encoding', ct => {
 })
 
 t.test('takes option for debug', ct => {
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   dotenv.config({ debug: 'true' })
   ct.ok(logStub.called)
@@ -231,7 +231,7 @@ t.test('returns any errors thrown from reading file or parsing', ct => {
 t.test('logs any errors thrown from reading file or parsing when in debug mode', ct => {
   ct.plan(2)
 
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
   const readFileSyncStub = sinon.stub(fs, 'readFileSync').returns('test=foo')
 
   readFileSyncStub.throws()
@@ -246,7 +246,7 @@ t.test('logs any errors thrown from reading file or parsing when in debug mode',
 t.test('logs any errors parsing when in debug and override mode', ct => {
   ct.plan(1)
 
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   dotenv.config({ debug: true, override: true })
 
@@ -254,7 +254,7 @@ t.test('logs any errors parsing when in debug and override mode', ct => {
 })
 
 t.test('deals with file:// path', ct => {
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   const testPath = 'file:///tests/.env'
   const env = dotenv.config({ path: testPath })
@@ -269,7 +269,7 @@ t.test('deals with file:// path', ct => {
 })
 
 t.test('deals with file:// path and debug true', ct => {
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   const testPath = 'file:///tests/.env'
   const env = dotenv.config({ path: testPath, debug: true })
@@ -284,7 +284,7 @@ t.test('deals with file:// path and debug true', ct => {
 })
 
 t.test('path.relative fails somehow', ct => {
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
   const pathRelativeStub = sinon.stub(path, 'relative').throws(new Error('fail'))
 
   const testPath = 'file:///tests/.env'
@@ -307,7 +307,7 @@ t.test('displays random tips from the tips array', ct => {
   const originalTTY = process.stdout.isTTY
   process.stdout.isTTY = true
 
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
   const testPath = 'tests/.env'
 
   // Test that tips are displayed (run config multiple times to see variation)
@@ -368,7 +368,7 @@ t.test('displays random tips from the tips array with fallback for isTTY false',
   const originalTTY = process.stdout.isTTY
   process.stdout.isTTY = undefined
 
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
   const testPath = 'tests/.env'
 
   // Test that tips are displayed (run config multiple times to see variation)
@@ -426,7 +426,7 @@ t.test('displays random tips from the tips array with fallback for isTTY false',
 t.test('logs when no path is set', ct => {
   ct.plan(1)
 
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   dotenv.config()
   ct.ok(logStub.called)
@@ -436,7 +436,7 @@ t.test('does log by default', ct => {
   ct.plan(1)
 
   const testPath = 'tests/.env'
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   dotenv.config({ path: testPath })
   ct.ok(logStub.called)
@@ -446,7 +446,7 @@ t.test('does not log if quiet flag passed true', ct => {
   ct.plan(1)
 
   const testPath = 'tests/.env'
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   dotenv.config({ path: testPath, quiet: true })
   ct.ok(logStub.notCalled)
@@ -457,7 +457,7 @@ t.test('does not log if process.env.DOTENV_CONFIG_QUIET is true', ct => {
 
   process.env.DOTENV_CONFIG_QUIET = 'true'
   const testPath = 'tests/.env'
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   dotenv.config({ path: testPath })
   ct.ok(logStub.notCalled)
@@ -468,7 +468,7 @@ t.test('does log if quiet flag false', ct => {
   ct.plan(1)
 
   const testPath = 'tests/.env'
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   dotenv.config({ path: testPath, quiet: false })
   ct.ok(logStub.called)
@@ -479,7 +479,7 @@ t.test('does log if process.env.DOTENV_CONFIG_QUIET is false', ct => {
 
   process.env.DOTENV_CONFIG_QUIET = 'false'
   const testPath = 'tests/.env'
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   dotenv.config({ path: testPath })
   ct.ok(logStub.called)
@@ -490,7 +490,7 @@ t.test('does log if quiet flag present and undefined/null', ct => {
   ct.plan(1)
 
   const testPath = 'tests/.env'
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   dotenv.config({ path: testPath, quiet: undefined })
   ct.ok(logStub.called)
@@ -500,7 +500,7 @@ t.test('logs if debug set', ct => {
   ct.plan(1)
 
   const testPath = 'tests/.env'
-  logStub = sinon.stub(console, 'log')
+  logStub = sinon.stub(console, 'error')
 
   dotenv.config({ path: testPath, debug: true })
   ct.ok(logStub.called)

--- a/tests/test-populate.js
+++ b/tests/test-populate.js
@@ -59,7 +59,7 @@ t.test('does write over keys already in processEnv if override turned on', ct =>
 t.test('logs any errors populating when in debug mode but override turned off', ct => {
   ct.plan(2)
 
-  const logStub = sinon.stub(console, 'log')
+  const logStub = sinon.stub(console, 'error')
 
   const parsed = { test: false }
   process.env.test = true
@@ -75,7 +75,7 @@ t.test('logs any errors populating when in debug mode but override turned off', 
 t.test('logs populating when debug mode and override turned on', ct => {
   ct.plan(1)
 
-  const logStub = sinon.stub(console, 'log')
+  const logStub = sinon.stub(console, 'error')
 
   const parsed = { test: false }
   process.env.test = true


### PR DESCRIPTION
## What

Changed `_log()` and `_debug()` functions in `lib/main.js` to write to `stderr` (`console.error`) instead of `stdout` (`console.log`).

## Why

dotenv's informational log messages (injection summaries, tips, debug output) currently go to `stdout`, which breaks:

- **Piping** — scripts that pipe stdout to other tools get dotenv's messages mixed into structured data
- **MCP servers** — JSON-RPC communication over stdio fails because dotenv's log lines are not valid JSON (reported in the comments by multiple MCP server maintainers)
- **Any stdout-dependent protocol** — tools that read structured output from stdout get unexpected lines

`stderr` is the correct destination for diagnostic/informational messages per Unix convention. The `_warn()` function already correctly uses `console.error` — this PR makes `_log()` and `_debug()` consistent with that pattern.

## Changes

- `lib/main.js`: `_log()` and `_debug()` now use `console.error()` instead of `console.log()`
- Tests updated to stub `console.error` instead of `console.log` where testing log/debug output

## Tests

All 194 existing tests pass. No new tests needed — this is a one-line behavioral change in two functions.

Fixes #903