### PR TITLE
fix: use DotenvPopulateOptions type for populate() options parameter

### DIFF
--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -163,7 +163,7 @@ export function configDotenv(options?: DotenvConfigOptions): DotenvConfigOutput;
 export function populate(
   processEnv: DotenvPopulateInput,
   parsed: DotenvPopulateInput,
-  options?: DotenvConfigOptions
+  options?: DotenvPopulateOptions
 ): DotenvPopulateOutput;
 
 /**


### PR DESCRIPTION
## What

Changed the `populate()` function's third parameter type from `DotenvConfigOptions` to `DotenvPopulateOptions` in `lib/main.d.ts`.

## Why

The `populate()` function only uses `debug` and `override` from its options parameter ([lib/main.js lines 379-380](https://github.com/motdotla/dotenv/blob/master/lib/main.js#L379-L380)):

```js
const debug = Boolean(options && options.debug)
const override = Boolean(options && options.override)
```

But the TypeScript signature accepted `DotenvConfigOptions`, which includes `path`, `encoding`, `quiet`, `processEnv`, and `DOTENV_KEY` — none of which are used by `populate()`. This causes misleading autocomplete/IntelliSense suggestions.

A `DotenvPopulateOptions` interface already exists with exactly `debug` and `override`, so the fix is just using the correct type.

## Tests

- All 194 tests pass
- TypeScript type check passes (`npm run dts-check`)