### PR TITLE
fix: add types condition to config exports for TypeScript resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,14 @@
       "require": "./lib/main.js",
       "default": "./lib/main.js"
     },
-    "./config": "./config.js",
-    "./config.js": "./config.js",
+    "./config": {
+      "types": "./config.d.ts",
+      "default": "./config.js"
+    },
+    "./config.js": {
+      "types": "./config.d.ts",
+      "default": "./config.js"
+    },
     "./lib/env-options": "./lib/env-options.js",
     "./lib/env-options.js": "./lib/env-options.js",
     "./lib/cli-options": "./lib/cli-options.js",


### PR DESCRIPTION
## What

Added explicit `types` conditions to the `./config` and `./config.js` export entries in `package.json`.

## Why

The `"."` export already includes a `types` condition:
```json
".": {
  "types": "./lib/main.d.ts",
  "require": "./lib/main.js",
  "default": "./lib/main.js"
}
```

But `./config` and `./config.js` used shorthand string syntax:
```json
"./config": "./config.js"
```

This relies on TypeScript's implicit `.d.ts` sibling resolution, which works in most cases but is not guaranteed with all bundlers and TypeScript's `moduleResolution: "node16"` or `"bundler"` modes. The [TypeScript documentation recommends](https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-exports) always including explicit `types` conditions in exports maps.

## After

```json
"./config": {
  "types": "./config.d.ts",
  "default": "./config.js"
},
"./config.js": {
  "types": "./config.d.ts",
  "default": "./config.js"
}
```

## Tests

All 194 tests pass. TypeScript type check passes.