### PR TITLE
docs: fix function count and remove incorrect parse options

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,11 +578,13 @@ Alternatively, just use [dotenv-webpack](https://github.com/mrsteele/dotenv-webp
 
 ## Docs
 
-Dotenv exposes four functions:
+Dotenv exposes five functions:
 
 * `config`
+* `configDotenv`
 * `parse`
 * `populate`
+* `decrypt`
 
 ### Config
 
@@ -700,22 +702,6 @@ const dotenv = require('dotenv')
 const buf = Buffer.from('BASIC=basic')
 const config = dotenv.parse(buf) // will return an object
 console.log(typeof config, config) // object { BASIC : 'basic' }
-```
-
-#### Options
-
-##### debug
-
-Default: `false`
-
-Turn on logging to help debug why certain keys or values are not being set as you expect.
-
-```js
-const dotenv = require('dotenv')
-const buf = Buffer.from('hello world')
-const opt = { debug: true }
-const config = dotenv.parse(buf, opt)
-// expect a debug message because the buffer is not in KEY=VAL form
 ```
 
 ### Populate


### PR DESCRIPTION
## What

Two fixes in the Docs section of README.md:

1. **Fixed function count**: The docs stated "Dotenv exposes four functions" but only listed three (`config`, `parse`, `populate`). Updated to list all five public functions including `configDotenv` and `decrypt`.

2. **Removed incorrect parse options**: The Parse section documented a `debug` option with an example, but `parse()` only accepts a single `src` parameter — it has no options argument. The TypeScript declaration confirms this:
   ```typescript
   export function parse<T>(src: string | Buffer): T;
   ```

## Tests

All 194 tests pass.