### PR TITLE
test: add tests for populate() return value

### DIFF
--- a/tests/test-populate.js
+++ b/tests/test-populate.js
@@ -89,6 +89,42 @@ t.test('logs populating when debug mode and override turned on', ct => {
   logStub.restore()
 })
 
+t.test('returns object with only newly set keys', ct => {
+  ct.plan(2)
+
+  const processEnv = {}
+  const parsed = { NEW_KEY: 'new_value', ANOTHER: 'another_value' }
+
+  const result = dotenv.populate(processEnv, parsed)
+
+  ct.same(result, { NEW_KEY: 'new_value', ANOTHER: 'another_value' })
+  ct.same(processEnv, { NEW_KEY: 'new_value', ANOTHER: 'another_value' })
+})
+
+t.test('returns object excluding keys that already existed without override', ct => {
+  ct.plan(2)
+
+  const processEnv = { EXISTING: 'original' }
+  const parsed = { EXISTING: 'new_value', FRESH: 'fresh_value' }
+
+  const result = dotenv.populate(processEnv, parsed)
+
+  ct.same(result, { FRESH: 'fresh_value' })
+  ct.equal(processEnv.EXISTING, 'original')
+})
+
+t.test('returns object including overridden keys when override is true', ct => {
+  ct.plan(2)
+
+  const processEnv = { EXISTING: 'original' }
+  const parsed = { EXISTING: 'new_value', FRESH: 'fresh_value' }
+
+  const result = dotenv.populate(processEnv, parsed, { override: true })
+
+  ct.same(result, { EXISTING: 'new_value', FRESH: 'fresh_value' })
+  ct.equal(processEnv.EXISTING, 'new_value')
+})
+
 t.test('returns any errors thrown on passing not json type', ct => {
   ct.plan(1)
 


### PR DESCRIPTION
## What

Added 3 new test cases for the `populate()` function's return value in `tests/test-populate.js`.

## Why

The `populate()` function returns an object containing only the keys that were actually set (used by `configDotenv` for the injection count in log messages). This return behavior had no test coverage.

## New Tests

| Test | Scenario | Expected Return |
|------|----------|----------------|
| All new keys | Empty target, two new keys | Both keys returned |
| Existing key without override | One existing key, one new key | Only new key returned |
| Existing key with override | One existing key, one new key, `override: true` | Both keys returned |

## Tests

All 200 tests pass (194 existing + 6 new, 3 in this PR + 3 already existed in previous run).