### PR TITLE
test: add tests for boolean parsing of DOTENV_CONFIG_QUIET values

### DIFF
--- a/tests/test-config.js
+++ b/tests/test-config.js
@@ -505,3 +505,63 @@ t.test('logs if debug set', ct => {
   dotenv.config({ path: testPath, debug: true })
   ct.ok(logStub.called)
 })
+
+t.test('does not log if DOTENV_CONFIG_QUIET is 0', ct => {
+  ct.plan(1)
+
+  process.env.DOTENV_CONFIG_QUIET = '0'
+  const testPath = 'tests/.env'
+  logStub = sinon.stub(console, 'log')
+
+  dotenv.config({ path: testPath })
+  ct.ok(logStub.called)
+  delete process.env.DOTENV_CONFIG_QUIET
+})
+
+t.test('does not log if DOTENV_CONFIG_QUIET is no', ct => {
+  ct.plan(1)
+
+  process.env.DOTENV_CONFIG_QUIET = 'no'
+  const testPath = 'tests/.env'
+  logStub = sinon.stub(console, 'log')
+
+  dotenv.config({ path: testPath })
+  ct.ok(logStub.called)
+  delete process.env.DOTENV_CONFIG_QUIET
+})
+
+t.test('does not log if DOTENV_CONFIG_QUIET is off', ct => {
+  ct.plan(1)
+
+  process.env.DOTENV_CONFIG_QUIET = 'off'
+  const testPath = 'tests/.env'
+  logStub = sinon.stub(console, 'log')
+
+  dotenv.config({ path: testPath })
+  ct.ok(logStub.called)
+  delete process.env.DOTENV_CONFIG_QUIET
+})
+
+t.test('suppresses log if DOTENV_CONFIG_QUIET is 1', ct => {
+  ct.plan(1)
+
+  process.env.DOTENV_CONFIG_QUIET = '1'
+  const testPath = 'tests/.env'
+  logStub = sinon.stub(console, 'log')
+
+  dotenv.config({ path: testPath })
+  ct.ok(logStub.notCalled)
+  delete process.env.DOTENV_CONFIG_QUIET
+})
+
+t.test('suppresses log if DOTENV_CONFIG_QUIET is yes', ct => {
+  ct.plan(1)
+
+  process.env.DOTENV_CONFIG_QUIET = 'yes'
+  const testPath = 'tests/.env'
+  logStub = sinon.stub(console, 'log')
+
+  dotenv.config({ path: testPath })
+  ct.ok(logStub.notCalled)
+  delete process.env.DOTENV_CONFIG_QUIET
+})


### PR DESCRIPTION
## What

Added 5 new test cases for `DOTENV_CONFIG_QUIET` environment variable boolean parsing in `tests/test-config.js`.

## Why

The existing tests only cover `DOTENV_CONFIG_QUIET=true` and `DOTENV_CONFIG_QUIET=false`. The `parseBoolean` function also accepts `0`, `no`, `off`, `1`, `yes`, etc., but these had no test coverage.

## New Tests

| Value | Expected Behavior |
|-------|-------------------|
| `0` | Treated as falsy — logs are shown |
| `no` | Treated as falsy — logs are shown |
| `off` | Treated as falsy — logs are shown |
| `1` | Treated as truthy — logs suppressed |
| `yes` | Treated as truthy — logs suppressed |

## Tests

All 199 tests pass (194 existing + 5 new).