### PR TITLE
test: add decrypt error case tests

### DIFF
--- a/tests/test-decrypt.js
+++ b/tests/test-decrypt.js
@@ -12,3 +12,47 @@ t.test('can decrypt', ct => {
 
   ct.equal(result, '# development@v6\nALPHA="zeta"')
 })
+
+t.test('throws INVALID_DOTENV_KEY when key is too short', ct => {
+  ct.plan(2)
+
+  const encrypted = 's7NYXa809k/bVSPwIAmJhPJmEGTtU0hG58hOZy7I0ix6y5HP8LsHBsZCYC/gw5DDFy5DgOcyd18R'
+  const shortKey = 'abcd1234'
+
+  try {
+    dotenv.decrypt(encrypted, shortKey)
+    ct.fail('should have thrown')
+  } catch (e) {
+    ct.equal(e.code, 'INVALID_DOTENV_KEY')
+    ct.match(e.message, 'INVALID_DOTENV_KEY')
+  }
+})
+
+t.test('throws DECRYPTION_FAILED when key is wrong', ct => {
+  ct.plan(2)
+
+  const encrypted = 's7NYXa809k/bVSPwIAmJhPJmEGTtU0hG58hOZy7I0ix6y5HP8LsHBsZCYC/gw5DDFy5DgOcyd18R'
+  const wrongKey = '0000000000000000000000000000000000000000000000000000000000000000'
+
+  try {
+    dotenv.decrypt(encrypted, wrongKey)
+    ct.fail('should have thrown')
+  } catch (e) {
+    ct.equal(e.code, 'DECRYPTION_FAILED')
+    ct.match(e.message, 'DECRYPTION_FAILED')
+  }
+})
+
+t.test('throws INVALID_DOTENV_KEY when key is empty string', ct => {
+  ct.plan(2)
+
+  const encrypted = 's7NYXa809k/bVSPwIAmJhPJmEGTtU0hG58hOZy7I0ix6y5HP8LsHBsZCYC/gw5DDFy5DgOcyd18R'
+
+  try {
+    dotenv.decrypt(encrypted, '')
+    ct.fail('should have thrown')
+  } catch (e) {
+    ct.equal(e.code, 'INVALID_DOTENV_KEY')
+    ct.match(e.message, 'INVALID_DOTENV_KEY')
+  }
+})


### PR DESCRIPTION
## Summary
- Add tests for `decrypt()` error paths that were previously untested
- Tests cover `INVALID_DOTENV_KEY` (short key, empty key) and `DECRYPTION_FAILED` (wrong key) error codes
- Only 1 test existed for decrypt; this brings coverage to 4 tests

## Test plan
- [x] All existing tests pass (`npm test` — 200 pass)
- [x] New tests verify error codes and messages match expected values