### PR TITLE
docs: fix function count and remove incorrect parse options in README-es

### DIFF
--- a/README-es.md
+++ b/README-es.md
@@ -578,11 +578,13 @@ Alternatively, just use [dotenv-webpack](https://github.com/mrsteele/dotenv-webp
 
 ## Docs
 
-Dotenv exposes four functions:
+Dotenv exposes five functions:
 
 * `config`
+* `configDotenv`
 * `parse`
 * `populate`
+* `decrypt`
 
 ### Config
 
@@ -700,22 +702,6 @@ const dotenv = require('dotenv')
 const buf = Buffer.from('BASIC=basic')
 const config = dotenv.parse(buf) // will return an object
 console.log(typeof config, config) // object { BASIC : 'basic' }
-```
-
-#### Options
-
-##### debug
-
-Default: `false`
-
-Turn on logging to help debug why certain keys or values are not being set as you expect.
-
-```js
-const dotenv = require('dotenv')
-const buf = Buffer.from('hello world')
-const opt = { debug: true }
-const config = dotenv.parse(buf, opt)
-// expect a debug message because the buffer is not in KEY=VAL form
 ```
 
 ### Populate


### PR DESCRIPTION
## Summary
- Fix "four functions" to "five functions" in the Spanish README, listing `config`, `configDotenv`, `parse`, `populate`, and `decrypt`
- Remove incorrect `Options` section under `Parse` that documented a `debug` option — `parse()` only accepts `src` (String or Buffer), not options
- Same fix as #946 but for `README-es.md`

## Test plan
- [x] All tests pass (`npm test` — 194 pass)
- [x] Verified `parse()` signature in source: only accepts `src` parameter