### PR TITLE
test: add missing cli-options tests for quiet and DOTENV_KEY

### DIFF
--- a/tests/test-cli-options.js
+++ b/tests/test-cli-options.js
@@ -26,6 +26,25 @@ t.same(options(['node', '-e', "'console.log(testing)'", 'dotenv_config_override=
   quiet: 'true'
 })
 
+// matches quiet option
+t.same(options(['node', '-e', "'console.log(testing)'", 'dotenv_config_quiet=true']), {
+  quiet: 'true'
+})
+
+// matches quiet option set to false (overrides default)
+t.same(options(['node', '-e', "'console.log(testing)'", 'dotenv_config_quiet=false']), {
+  quiet: 'false'
+})
+
+// matches DOTENV_KEY option
+t.same(options(['node', '-e', "'console.log(testing)'", 'dotenv_config_DOTENV_KEY=dotenv://:key_1234@dotenvx.com/vault/.env.vault?environment=development']), {
+  DOTENV_KEY: 'dotenv://:key_1234@dotenvx.com/vault/.env.vault?environment=development',
+  quiet: 'true'
+})
+
+// defaults quiet to true when no quiet option provided
+t.same(options(['node', '-e', "'console.log(testing)'"]), { quiet: 'true' })
+
 // ignores empty values
 t.same(options(['node', '-e', "'console.log(testing)'", 'dotenv_config_path=']), { quiet: 'true' })
 


### PR DESCRIPTION
## Summary
- Add tests for `quiet` and `DOTENV_KEY` CLI options that were not covered in `test-cli-options.js`
- Add test verifying the default `quiet: 'true'` behavior when no quiet option is provided
- Add test verifying `quiet: 'false'` overrides the default

## Test plan
- [x] All tests pass (`npm test` — 198 pass)
- [x] New tests verify all supported CLI option patterns from the regex in `cli-options.js`