### PR TITLE
test: add TypeScript type tests for populate, configDotenv, and decrypt

### DIFF
--- a/tests/types/test.ts
+++ b/tests/types/test.ts
@@ -1,4 +1,4 @@
-import { config, parse } from "dotenv";
+import { config, configDotenv, parse, populate, decrypt, DotenvPopulateOutput } from "dotenv";
 
 const env = config();
 const dbUrl: string | null =
@@ -8,6 +8,26 @@ config({
   path: ".env-example",
   encoding: "utf8",
   debug: true,
+});
+
+// config accepts array of paths
+config({
+  path: [".env.local", ".env"],
+});
+
+// config accepts override option
+config({
+  override: true,
+});
+
+// config accepts quiet option
+config({
+  quiet: true,
+});
+
+// config accepts DOTENV_KEY option
+config({
+  DOTENV_KEY: "dotenv://:key_1234@dotenvx.com/vault/.env.vault?environment=production",
 });
 
 parse("test");
@@ -22,3 +42,34 @@ config({
   // make sure the type accepts process.env (it didn't in the past)
   processEnv: process.env,
 });
+
+// configDotenv works same as config
+const envDotenv = configDotenv();
+const dbUrl2: string | null =
+  envDotenv.error || !envDotenv.parsed ? null : envDotenv.parsed["BASIC"];
+
+configDotenv({
+  path: ".env",
+  encoding: "utf8",
+  debug: true,
+  override: true,
+  quiet: true,
+});
+
+// populate accepts target and source objects
+const target: { [name: string]: string } = {};
+const source: { [name: string]: string } = { KEY: "value" };
+const populateResult: DotenvPopulateOutput = populate(target, source);
+const populatedValue: string = populateResult["KEY"];
+
+// populate accepts options
+populate(target, source, { debug: true, override: true });
+
+// populate works with process.env
+populate(process.env, { HELLO: "world" });
+
+// decrypt returns a string
+const decrypted: string = decrypt(
+  "s7NYXa809k/bVSPwIAmJhPJmEGTtU0hG58hOZy7I0ix6y5HP8LsHBsZCYC/gw5DDFy5DgOcyd18R",
+  "ddcaa26504cd70a6fef9801901c3981538563a1767c297cb8416e8a38c62fe00"
+);


### PR DESCRIPTION
## Summary
- Add type tests for `configDotenv()`, `populate()`, and `decrypt()` which had no type coverage
- Add type tests for `config()` options that weren't tested: array paths, `quiet`, `override`, `DOTENV_KEY`
- Import and verify `DotenvPopulateOutput` return type from `populate()`

## Test plan
- [x] TypeScript check passes (`npx tsc --project tests/types/tsconfig.json`)
- [x] All tests pass (`npm test` — 194 pass)