### PR TITLE
fix: typo in test description "mulit-array" to "multi-array"

### DIFF
--- a/tests/test-config-vault.js
+++ b/tests/test-config-vault.js
@@ -89,7 +89,7 @@ t.test('returns parsed object (set path as array)', ct => {
   ct.end()
 })
 
-t.test('returns parsed object (set path as mulit-array)', ct => {
+t.test('returns parsed object (set path as multi-array)', ct => {
   ct.plan(1)
 
   const env = dotenv.config({ path: ['tests/.env.local', 'tests/.env'] })


### PR DESCRIPTION
## Summary
- Fix typo in `test-config-vault.js` test description: "mulit-array" → "multi-array"

## Test plan
- [x] All tests pass (`npm test` — 194 pass)