### PR TITLE
fix: remove dead individual exports overwritten by module.exports assignment

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -420,12 +420,4 @@ const DotenvModule = {
   populate
 }
 
-module.exports.configDotenv = DotenvModule.configDotenv
-module.exports._configVault = DotenvModule._configVault
-module.exports._parseVault = DotenvModule._parseVault
-module.exports.config = DotenvModule.config
-module.exports.decrypt = DotenvModule.decrypt
-module.exports.parse = DotenvModule.parse
-module.exports.populate = DotenvModule.populate
-
 module.exports = DotenvModule


### PR DESCRIPTION
## Summary
- Remove 7 individual `module.exports.X = ...` property assignments that were dead code
- These assignments on lines 423-429 were immediately overwritten by `module.exports = DotenvModule` on line 431
- The `DotenvModule` object already contains all the same properties, so the final assignment is sufficient

## Test plan
- [x] All tests pass (`npm test` — 194 pass)
- [x] Verified `module.exports = DotenvModule` exports all functions correctly (configDotenv, _configVault, _parseVault, config, decrypt, parse, populate)