### PR TITLE
test: verify vault missing warning uses console.error

### DIFF
--- a/tests/test-config-vault.js
+++ b/tests/test-config-vault.js
@@ -35,29 +35,35 @@ t.test('does log when testPath calls to .env.vault directly (interpret what the 
 })
 
 t.test('warns if DOTENV_KEY exists but .env.vault does not exist', ct => {
-  ct.plan(1)
+  ct.plan(2)
 
   const testPath = 'tests/.env'
   logStub = sinon.stub(console, 'log')
+  const errorStub = sinon.stub(console, 'error')
 
   const existsSync = sinon.stub(fs, 'existsSync').returns(false) // make .env.vault not exist
   dotenv.config({ path: testPath })
   ct.ok(logStub.called)
+  ct.ok(errorStub.called, 'should warn via console.error')
   existsSync.restore()
+  errorStub.restore()
 
   ct.end()
 })
 
 t.test('warns if DOTENV_KEY exists but .env.vault does not exist (set as array)', ct => {
-  ct.plan(1)
+  ct.plan(2)
 
   const testPath = 'tests/.env'
   logStub = sinon.stub(console, 'log')
+  const errorStub = sinon.stub(console, 'error')
 
   const existsSync = sinon.stub(fs, 'existsSync').returns(false) // make .env.vault not exist
   dotenv.config({ path: [testPath] })
   ct.ok(logStub.called)
+  ct.ok(errorStub.called, 'should warn via console.error')
   existsSync.restore()
+  errorStub.restore()
 
   ct.end()
 })


### PR DESCRIPTION
## Summary
- Fix vault warning tests to actually verify the `_warn()` call via `console.error`
- Previously, these tests only stubbed `console.log` and passed because the `configDotenv` fallback calls `_log()` (which uses `console.log`), not because the warning was verified
- The `_warn` function has always used `console.error`, but the tests never checked it

## Test plan
- [x] All tests pass (`npm test` — 196 pass)
- [x] New assertions verify `console.error` is called when vault file is missing