### PR TITLE
chore: add *.tgz and *.log to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ coverage/
 node_modules/
 .idea/
 .vscode
+*.tgz
+*.log


### PR DESCRIPTION
## Summary
- Add `*.tgz` to ignore npm pack artifacts that can be accidentally committed
- Add `*.log` to ignore npm debug log files (e.g., `npm-debug.log`)

## Test plan
- [x] All tests pass (`npm test` — 194 pass)