### PR TITLE
test: add quiet option tests for vault config

### DIFF
--- a/tests/test-config-vault.js
+++ b/tests/test-config-vault.js
@@ -357,6 +357,28 @@ t.test('raises error if some other uncaught decryption error', ct => {
   ct.end()
 })
 
+t.test('does not log when quiet is true', ct => {
+  ct.plan(2)
+
+  logStub = sinon.stub(console, 'log')
+
+  const result = dotenv.config({ path: testPath, quiet: true })
+
+  ct.same(result.parsed, { ALPHA: 'zeta' })
+  ct.ok(logStub.notCalled)
+})
+
+t.test('does log when quiet is true but debug is also true', ct => {
+  ct.plan(2)
+
+  logStub = sinon.stub(console, 'log')
+
+  const result = dotenv.config({ path: testPath, quiet: true, debug: true })
+
+  ct.same(result.parsed, { ALPHA: 'zeta' })
+  ct.ok(logStub.called)
+})
+
 t.test('_parseVault when empty args', ct => {
   ct.plan(1)
 


### PR DESCRIPTION
## Summary

- Add test verifying `quiet: true` suppresses the vault loading log message
- Add test verifying `debug: true` overrides `quiet: true` to still show logs

The `_configVault` function supports `quiet` and `debug` options but had no test coverage for this behavior.

## Test plan

- [x] `npm test` passes (198 tests)
- [x] No new dependencies