### PR TITLE
test: add parse tests for dotted and hyphenated key names

### DIFF
--- a/tests/test-parse.js
+++ b/tests/test-parse.js
@@ -95,3 +95,12 @@ t.same(NPayload, expectedPayload, 'can parse (\\n) line endings')
 
 const RNPayload = dotenv.parse(Buffer.from('SERVER=localhost\r\nPASSWORD=password\r\nDB=tests\r\n'))
 t.same(RNPayload, expectedPayload, 'can parse (\\r\\n) line endings')
+
+const dottedKey = dotenv.parse('api.host=localhost')
+t.equal(dottedKey['api.host'], 'localhost', 'parses keys with dots')
+
+const hyphenKey = dotenv.parse('my-key=value')
+t.equal(hyphenKey['my-key'], 'value', 'parses keys with hyphens')
+
+const dottedHyphenKey = dotenv.parse('my-app.port=3000')
+t.equal(dottedHyphenKey['my-app.port'], '3000', 'parses keys with dots and hyphens')


### PR DESCRIPTION
## Summary

- Add tests for keys with dots (e.g. `api.host=localhost`)
- Add tests for keys with hyphens (e.g. `my-key=value`)
- Add test for keys with both dots and hyphens

The parse regex supports `[\w.-]+` key names but had no coverage for dot and hyphen characters.

## Test plan

- [x] `npm test` passes (197 tests)
- [x] No new dependencies