### PR TITLE
test: add CLI override option test for preload

### DIFF
--- a/tests/test-config-cli.js
+++ b/tests/test-config-cli.js
@@ -21,7 +21,7 @@ function spawn (cmd, options = {}) {
   return stdout
 }
 
-t.plan(3)
+t.plan(4)
 
 // dotenv/config enables preloading
 t.equal(
@@ -69,6 +69,26 @@ t.equal(
     {
       env: {
         DOTENV_CONFIG_PATH: '/tmp/dne/path/.env.should.break'
+      }
+    }
+  ),
+  'basic\n'
+)
+
+// dotenv/config supports override via CLI args
+t.equal(
+  spawn(
+    [
+      '-r',
+      './config',
+      '-e',
+      'console.log(process.env.BASIC)',
+      'dotenv_config_path=./tests/.env',
+      'dotenv_config_override=true'
+    ],
+    {
+      env: {
+        BASIC: 'existing'
       }
     }
   ),


### PR DESCRIPTION
## Summary

- Add test verifying `dotenv_config_override=true` CLI argument correctly overrides existing environment variables during preload with `node -r dotenv/config`

The existing CLI tests cover path and encoding but not override.

## Test plan

- [x] `npm test` passes (195 tests)
- [x] No new dependencies