### PR TITLE
test: add tests for populate() return value with partial keys

### DIFF
--- a/tests/test-populate.js
+++ b/tests/test-populate.js
@@ -89,6 +89,31 @@ t.test('logs populating when debug mode and override turned on', ct => {
   logStub.restore()
 })
 
+t.test('returns only the keys that were actually set', ct => {
+  ct.plan(2)
+
+  const processEnv = { EXISTING: 'keep' }
+  const parsed = { EXISTING: 'overwrite', NEW_KEY: 'new' }
+
+  const result = dotenv.populate(processEnv, parsed)
+
+  // EXISTING was skipped (no override), NEW_KEY was set
+  ct.equal(result.NEW_KEY, 'new')
+  ct.notOk(result.EXISTING)
+})
+
+t.test('returns all keys when override is true', ct => {
+  ct.plan(2)
+
+  const processEnv = { EXISTING: 'keep' }
+  const parsed = { EXISTING: 'overwrite', NEW_KEY: 'new' }
+
+  const result = dotenv.populate(processEnv, parsed, { override: true })
+
+  ct.equal(result.EXISTING, 'overwrite')
+  ct.equal(result.NEW_KEY, 'new')
+})
+
 t.test('returns any errors thrown on passing not json type', ct => {
   ct.plan(1)
 


### PR DESCRIPTION
## Summary

- Add test verifying `populate()` returns only keys that were actually set (skipped keys excluded)
- Add test verifying `populate()` returns all keys when `override: true`

The `populate()` function returns a `populated` object tracking which keys were set, but this return value had no test coverage.

## Test plan

- [x] `npm test` passes (198 tests)
- [x] No new dependencies