### PR TITLE
test: add parse tests for colon separator syntax

### DIFF
--- a/tests/test-parse.js
+++ b/tests/test-parse.js
@@ -95,3 +95,9 @@ t.same(NPayload, expectedPayload, 'can parse (\\n) line endings')
 
 const RNPayload = dotenv.parse(Buffer.from('SERVER=localhost\r\nPASSWORD=password\r\nDB=tests\r\n'))
 t.same(RNPayload, expectedPayload, 'can parse (\\r\\n) line endings')
+
+const colonParsed = dotenv.parse('KEY: value')
+t.equal(colonParsed.KEY, 'value', 'parses colon-separated values')
+
+const colonQuoted = dotenv.parse('KEY: "quoted value"')
+t.equal(colonQuoted.KEY, 'quoted value', 'parses colon-separated quoted values')


### PR DESCRIPTION
## Summary

- Add test for colon-space separator parsing (e.g. `KEY: value`)
- Add test for colon-space with double quotes (e.g. `KEY: "quoted value"`)

The parse regex supports both `=` and `: ` as key-value separators but only `=` had test coverage.

## Test plan

- [x] `npm test` passes (196 tests)
- [x] No new dependencies