### PR TITLE
test: verify DOTENV_CONFIG_QUIET from .env file suppresses log

### DIFF
--- a/tests/.env.quiet
+++ b/tests/.env.quiet
@@ -1,0 +1,2 @@
+DOTENV_CONFIG_QUIET=true
+HELLO=world

--- a/tests/test-config.js
+++ b/tests/test-config.js
@@ -505,3 +505,14 @@ t.test('logs if debug set', ct => {
   dotenv.config({ path: testPath, debug: true })
   ct.ok(logStub.called)
 })
+
+t.test('suppresses log when DOTENV_CONFIG_QUIET is set inside .env file', ct => {
+  ct.plan(2)
+
+  logStub = sinon.stub(console, 'log')
+
+  const env = dotenv.config({ path: 'tests/.env.quiet' })
+
+  ct.equal(env.parsed.HELLO, 'world')
+  ct.ok(logStub.notCalled)
+})


### PR DESCRIPTION
## Summary

- Add test verifying that `DOTENV_CONFIG_QUIET=true` set inside the `.env` file itself properly suppresses the log message
- Add `.env.quiet` test fixture with `DOTENV_CONFIG_QUIET=true`

This tests the re-read logic in `configDotenv` (lines 298-300) where `DOTENV_CONFIG_QUIET` is re-evaluated from processEnv after population, allowing users to set it inside their `.env` file.

## Test plan

- [x] `npm test` passes (196 tests)
- [x] No new dependencies