### PR TITLE
test: add tilde home directory expansion test for array paths

### DIFF
--- a/tests/test-config.js
+++ b/tests/test-config.js
@@ -108,6 +108,22 @@ t.test('takes option for path along with home directory char ~', ct => {
   ct.end()
 })
 
+t.test('takes option for path along with home directory char ~ in array', ct => {
+  const readFileSyncStub = sinon.stub(fs, 'readFileSync').returns('test=foo')
+  const mockedHomedir = '/Users/dummy'
+  const homedirStub = sinon.stub(os, 'homedir').returns(mockedHomedir)
+  const testPaths = ['~/.env.local', '~/.env']
+  dotenv.config({ path: testPaths })
+
+  ct.equal(readFileSyncStub.args[0][0], path.join(mockedHomedir, '.env.local'))
+  ct.equal(readFileSyncStub.args[1][0], path.join(mockedHomedir, '.env'))
+  ct.ok(homedirStub.called)
+
+  homedirStub.restore()
+  readFileSyncStub.restore()
+  ct.end()
+})
+
 t.test('takes option for encoding', ct => {
   const readFileSyncStub = sinon.stub(fs, 'readFileSync').returns('test=foo')
 


### PR DESCRIPTION
## Summary

- Add test verifying `~` home directory expansion works correctly when `path` option is an array (e.g. `{ path: ['~/.env.local', '~/.env'] }`)

The existing `~` expansion test only covers single path strings. Array paths go through the same `_resolveHome` function but via a different code branch.

## Test plan

- [x] `npm test` passes (197 tests)
- [x] No new dependencies