### PR TITLE
docs: remove trailing whitespace from README files

### DIFF
--- a/README-es.md
+++ b/README-es.md
@@ -479,7 +479,7 @@ Use [dotenvx](https://github.com/dotenvx/dotenvx) to unlock syncing encrypted .e
 </details>
 <details><summary>What if I accidentally commit my `.env` file to code?</summary><br/>
 
-Remove it, [remove git history](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository) and then install the [git pre-commit hook](https://github.com/dotenvx/dotenvx#pre-commit) to prevent this from ever happening again. 
+Remove it, [remove git history](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository) and then install the [git pre-commit hook](https://github.com/dotenvx/dotenvx#pre-commit) to prevent this from ever happening again.
 
 ```
 npm i -g @dotenvx/dotenvx
@@ -616,9 +616,9 @@ require('dotenv').config({ path: '/custom/path/to/.env' })
 
 By default, `config` will look for a file called .env in the current working directory.
 
-Pass in multiple files as an array, and they will be parsed in order and combined with `process.env` (or `option.processEnv`, if set). The first value set for a variable will win, unless the `options.override` flag is set, in which case the last value set will win.  If a value already exists in `process.env` and the `options.override` flag is NOT set, no changes will be made to that value. 
+Pass in multiple files as an array, and they will be parsed in order and combined with `process.env` (or `option.processEnv`, if set). The first value set for a variable will win, unless the `options.override` flag is set, in which case the last value set will win. If a value already exists in `process.env` and the `options.override` flag is NOT set, no changes will be made to that value.
 
-```js  
+```js
 require('dotenv').config({ path: ['.env.local', '.env'] })
 ```
 
@@ -669,7 +669,7 @@ require('dotenv').config({ debug: process.env.DEBUG })
 
 Default: `false`
 
-Override any environment variables that have already been set on your machine with values from your .env file(s). If multiple files have been provided in `option.path` the override will also be used as each file is combined with the next. Without `override` being set, the first value wins. With `override` set the last value wins. 
+Override any environment variables that have already been set on your machine with values from your .env file(s). If multiple files have been provided in `option.path` the override will also be used as each file is combined with the next. Without `override` being set, the first value wins. With `override` set the last value wins.
 
 ```js
 require('dotenv').config({ override: true })

--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ Use [dotenvx](https://github.com/dotenvx/dotenvx) to unlock syncing encrypted .e
 </details>
 <details><summary>What if I accidentally commit my `.env` file to code?</summary><br/>
 
-Remove it, [remove git history](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository) and then install the [git pre-commit hook](https://github.com/dotenvx/dotenvx#pre-commit) to prevent this from ever happening again. 
+Remove it, [remove git history](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository) and then install the [git pre-commit hook](https://github.com/dotenvx/dotenvx#pre-commit) to prevent this from ever happening again.
 
 ```
 npm i -g @dotenvx/dotenvx
@@ -616,9 +616,9 @@ require('dotenv').config({ path: '/custom/path/to/.env' })
 
 By default, `config` will look for a file called .env in the current working directory.
 
-Pass in multiple files as an array, and they will be parsed in order and combined with `process.env` (or `option.processEnv`, if set). The first value set for a variable will win, unless the `options.override` flag is set, in which case the last value set will win.  If a value already exists in `process.env` and the `options.override` flag is NOT set, no changes will be made to that value. 
+Pass in multiple files as an array, and they will be parsed in order and combined with `process.env` (or `option.processEnv`, if set). The first value set for a variable will win, unless the `options.override` flag is set, in which case the last value set will win. If a value already exists in `process.env` and the `options.override` flag is NOT set, no changes will be made to that value.
 
-```js  
+```js
 require('dotenv').config({ path: ['.env.local', '.env'] })
 ```
 
@@ -669,7 +669,7 @@ require('dotenv').config({ debug: process.env.DEBUG })
 
 Default: `false`
 
-Override any environment variables that have already been set on your machine with values from your .env file(s). If multiple files have been provided in `option.path` the override will also be used as each file is combined with the next. Without `override` being set, the first value wins. With `override` set the last value wins. 
+Override any environment variables that have already been set on your machine with values from your .env file(s). If multiple files have been provided in `option.path` the override will also be used as each file is combined with the next. Without `override` being set, the first value wins. With `override` set the last value wins.
 
 ```js
 require('dotenv').config({ override: true })


### PR DESCRIPTION
## Summary

- Remove trailing whitespace from README.md and README-es.md
- Fix double spaces and trailing spaces in code fence markers

These are minor formatting cleanups matching the project's `.editorconfig` settings.

## Test plan

- [x] `npm test` passes
- [x] No code changes