### PR TITLE
docs: fix typo "form" to "from" in README-es.md

### DIFF
--- a/README-es.md
+++ b/README-es.md
@@ -370,7 +370,7 @@ Use [dotenvx](https://github.com/dotenvx/dotenvx).
 </details>
 <details><summary>Should I have multiple `.env` files?</summary><br/>
 
-We recommend creating one `.env` file per environment. Use `.env` for local/development, `.env.production` for production and so on. This still follows the twelve factor principles as each is attributed individually to its own environment. Avoid custom set ups that work in inheritance somehow (`.env.production` inherits values form `.env` for example). It is better to duplicate values if necessary across each `.env.environment` file.
+We recommend creating one `.env` file per environment. Use `.env` for local/development, `.env.production` for production and so on. This still follows the twelve factor principles as each is attributed individually to its own environment. Avoid custom set ups that work in inheritance somehow (`.env.production` inherits values from `.env` for example). It is better to duplicate values if necessary across each `.env.environment` file.
 
 > In a twelve-factor app, env vars are granular controls, each fully orthogonal to other env vars. They are never grouped together as “environments”, but instead are independently managed for each deploy. This is a model that scales up smoothly as the app naturally expands into more deploys over its lifetime.
 >


### PR DESCRIPTION
## Summary

Fix typo in README-es.md FAQ section: "inherits values form .env" → "inherits values from .env"

The English README has the correct wording.

## Test plan

- [x] No code changes