### PR TITLE
test: add decrypt output parsing and type tests

### DIFF
--- a/tests/test-decrypt.js
+++ b/tests/test-decrypt.js
@@ -12,3 +12,26 @@ t.test('can decrypt', ct => {
 
   ct.equal(result, '# development@v6\nALPHA="zeta"')
 })
+
+t.test('decrypted output is parseable by parse()', ct => {
+  ct.plan(1)
+
+  const encrypted = 's7NYXa809k/bVSPwIAmJhPJmEGTtU0hG58hOZy7I0ix6y5HP8LsHBsZCYC/gw5DDFy5DgOcyd18R'
+  const keyStr = 'ddcaa26504cd70a6fef9801901c3981538563a1767c297cb8416e8a38c62fe00'
+
+  const decrypted = dotenv.decrypt(encrypted, keyStr)
+  const parsed = dotenv.parse(decrypted)
+
+  ct.equal(parsed.ALPHA, 'zeta')
+})
+
+t.test('returns a string type', ct => {
+  ct.plan(1)
+
+  const encrypted = 's7NYXa809k/bVSPwIAmJhPJmEGTtU0hG58hOZy7I0ix6y5HP8LsHBsZCYC/gw5DDFy5DgOcyd18R'
+  const keyStr = 'ddcaa26504cd70a6fef9801901c3981538563a1767c297cb8416e8a38c62fe00'
+
+  const result = dotenv.decrypt(encrypted, keyStr)
+
+  ct.type(result, 'string')
+})


### PR DESCRIPTION
## Summary

- Add test verifying `decrypt()` output can be parsed by `parse()` (roundtrip test)
- Add test verifying `decrypt()` returns a string type

The existing test only checks the raw decrypted string value.

## Test plan

- [x] `npm test` passes (196 tests)
- [x] No new dependencies