### PR TITLE
fix: correct tsconfig include path for main.d.ts

### DIFF
--- a/tests/types/tsconfig.json
+++ b/tests/types/tsconfig.json
@@ -13,5 +13,5 @@
       "dotenv": ["../../lib/main.d.ts"]
     }
   },
-  "include": ["./test.ts", "../../main.d.ts"]
+  "include": ["./test.ts", "../../lib/main.d.ts"]
 }


### PR DESCRIPTION
## Summary

Fix incorrect path in `tests/types/tsconfig.json` include array:
- `../../main.d.ts` → `../../lib/main.d.ts`

The root `main.d.ts` does not exist; the type declarations are located at `lib/main.d.ts`.

## Test plan

- [x] `npm run dts-check` passes
- [x] `npm test` passes