### PR TITLE
test: add \\r carriage return expansion tests for parse

### DIFF
--- a/tests/test-parse.js
+++ b/tests/test-parse.js
@@ -95,3 +95,12 @@ t.same(NPayload, expectedPayload, 'can parse (\\n) line endings')
 
 const RNPayload = dotenv.parse(Buffer.from('SERVER=localhost\r\nPASSWORD=password\r\nDB=tests\r\n'))
 t.same(RNPayload, expectedPayload, 'can parse (\\r\\n) line endings')
+
+const expandCR = dotenv.parse('KEY="expand\\rcarriage"')
+t.equal(expandCR.KEY, 'expand\rcarriage', 'expands \\r in double quoted values')
+
+const noExpandCRUnquoted = dotenv.parse('KEY=expand\\rcarriage')
+t.equal(noExpandCRUnquoted.KEY, 'expand\\rcarriage', 'does not expand \\r in unquoted values')
+
+const noExpandCRSingle = dotenv.parse("KEY='expand\\rcarriage'")
+t.equal(noExpandCRSingle.KEY, 'expand\\rcarriage', 'does not expand \\r in single quoted values')


### PR DESCRIPTION
## Summary

- Add test verifying `\r` is expanded to carriage return in double-quoted values
- Add test verifying `\r` is NOT expanded in unquoted values
- Add test verifying `\r` is NOT expanded in single-quoted values

The parser expands both `\n` and `\r` in double-quoted values (lines 76-77 of main.js), but only `\n` expansion had test coverage.

## Test plan

- [x] `npm test` passes (197 tests)
- [x] No new dependencies