### PR TITLE
test: add backtick-quoted newline non-expansion test

### DIFF
--- a/tests/.env
+++ b/tests/.env
@@ -23,6 +23,7 @@ DOUBLE_AND_SINGLE_QUOTES_INSIDE_BACKTICKS=`double "quotes" and single 'quotes' w
 EXPAND_NEWLINES="expand\nnew\nlines"
 DONT_EXPAND_UNQUOTED=dontexpand\nnewlines
 DONT_EXPAND_SQUOTED='dontexpand\nnewlines'
+DONT_EXPAND_BACKTICKED=`dontexpand\nnewlines`
 # COMMENTS=work
 INLINE_COMMENTS=inline comments # work #very #well
 INLINE_COMMENTS_SINGLE_QUOTES='inline comments outside of #singlequotes' # work

--- a/tests/test-parse.js
+++ b/tests/test-parse.js
@@ -53,6 +53,8 @@ t.equal(parsed.DONT_EXPAND_UNQUOTED, 'dontexpand\\nnewlines', 'expands newlines 
 
 t.equal(parsed.DONT_EXPAND_SQUOTED, 'dontexpand\\nnewlines', 'expands newlines but only if double quoted')
 
+t.equal(parsed.DONT_EXPAND_BACKTICKED, 'dontexpand\\nnewlines', 'does not expand newlines in backtick quoted values')
+
 t.notOk(parsed.COMMENTS, 'ignores commented lines')
 
 t.equal(parsed.INLINE_COMMENTS, 'inline comments', 'ignores inline comments')


### PR DESCRIPTION
## Summary

- Add `DONT_EXPAND_BACKTICKED` to the `.env` test fixture
- Add test verifying `\n` is NOT expanded in backtick-quoted values

The existing tests cover `\n` non-expansion for unquoted and single-quoted values but were missing backtick-quoted values. Only double-quoted values should expand `\n`.

## Test plan

- [x] `npm test` passes (195 tests)
- [x] No new dependencies