### PR TITLE
test: add multi-path with override test for process.env

### DIFF
--- a/tests/test-config.js
+++ b/tests/test-config.js
@@ -505,3 +505,14 @@ t.test('logs if debug set', ct => {
   dotenv.config({ path: testPath, debug: true })
   ct.ok(logStub.called)
 })
+
+t.test('multi-path with override writes over existing process.env values', ct => {
+  process.env.BASIC = 'existing'
+
+  const testPath = ['tests/.env.local', 'tests/.env']
+  const env = dotenv.config({ path: testPath, override: true })
+
+  ct.equal(env.parsed.BASIC, 'basic', 'second file overrides first in parsed')
+  ct.equal(process.env.BASIC, 'basic', 'process.env overridden despite existing value')
+  ct.end()
+})


### PR DESCRIPTION
Adds a test verifying that `config()` with multiple paths and `override: true` correctly:

- Writes values to `process.env` even when keys already exist
- Uses the second file's values when both files define the same key (since override applies to the internal `parsedAll` aggregation too)