### PR TITLE
test: add decrypt error tests for short key and wrong key

### DIFF
--- a/tests/test-decrypt.js
+++ b/tests/test-decrypt.js
@@ -12,3 +12,28 @@ t.test('can decrypt', ct => {
 
   ct.equal(result, '# development@v6\nALPHA="zeta"')
 })
+
+t.test('throws on short key', ct => {
+  ct.plan(1)
+
+  const encrypted = 's7NYXa809k/bVSPwIAmJhPJmEGTtU0hG58hOZy7I0ix6y5HP8LsHBsZCYC/gw5DDFy5DgOcyd18R'
+
+  try {
+    dotenv.decrypt(encrypted, 'tooshort')
+  } catch (e) {
+    ct.equal(e.code, 'INVALID_DOTENV_KEY', 'throws INVALID_DOTENV_KEY for short key')
+  }
+})
+
+t.test('throws DECRYPTION_FAILED on wrong key', ct => {
+  ct.plan(1)
+
+  const encrypted = 's7NYXa809k/bVSPwIAmJhPJmEGTtU0hG58hOZy7I0ix6y5HP8LsHBsZCYC/gw5DDFy5DgOcyd18R'
+  const wrongKey = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+
+  try {
+    dotenv.decrypt(encrypted, wrongKey)
+  } catch (e) {
+    ct.equal(e.code, 'DECRYPTION_FAILED', 'throws DECRYPTION_FAILED for wrong key')
+  }
+})


### PR DESCRIPTION
Adds tests verifying `decrypt()` error handling:

- Throws `INVALID_DOTENV_KEY` for keys shorter than 64 characters
- Throws `DECRYPTION_FAILED` when the key doesn't match the ciphertext