### PR TITLE
fix: use DotenvPopulateOptions for populate() third argument type

### DIFF
--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -95,7 +95,7 @@ export interface DotenvConfigOutput {
 }
 
 type DotenvError = Error & {
-  code: 
+  code:
     | 'MISSING_DATA'
     | 'INVALID_DOTENV_KEY'
     | 'NOT_FOUND_DOTENV_ENVIRONMENT'
@@ -109,7 +109,7 @@ export interface DotenvPopulateOptions {
    *
    * Turn on logging to help debug why certain keys or values are not being set as you expect.
    *
-   * example: `require('dotenv').config({ debug: process.env.DEBUG })`
+   * example: `require('dotenv').populate(processEnv, parsed, { debug: true })`
    */
   debug?: boolean;
 
@@ -118,7 +118,7 @@ export interface DotenvPopulateOptions {
    *
    * Override any environment variables that have already been set on your machine with values from your .env file.
    *
-   * example: `require('dotenv').config({ override: true })`
+   * example: `require('dotenv').populate(processEnv, parsed, { override: true })`
    */
   override?: boolean;
 }
@@ -156,14 +156,14 @@ export function configDotenv(options?: DotenvConfigOptions): DotenvConfigOutput;
  *
  * @param processEnv - the target JSON object. in most cases use process.env but you can also pass your own JSON object
  * @param parsed - the source JSON object
- * @param options - additional options. example: `{ quiet: false, debug: true, override: false }`
+ * @param options - additional options. example: `{ debug: true, override: false }`
  * @returns an object with the keys and values that were actually set
  *
  */
 export function populate(
   processEnv: DotenvPopulateInput,
   parsed: DotenvPopulateInput,
-  options?: DotenvConfigOptions
+  options?: DotenvPopulateOptions
 ): DotenvPopulateOutput;
 
 /**

--- a/tests/types/test.ts
+++ b/tests/types/test.ts
@@ -1,4 +1,4 @@
-import { config, parse } from "dotenv";
+import { config, parse, populate, DotenvPopulateInput } from "dotenv";
 
 const env = config();
 const dbUrl: string | null =
@@ -22,3 +22,11 @@ config({
   // make sure the type accepts process.env (it didn't in the past)
   processEnv: process.env,
 });
+
+// populate() should accept DotenvPopulateOptions (debug + override only),
+// not the broader DotenvConfigOptions
+const target: DotenvPopulateInput = {};
+populate(target, { DB_HOST: "localhost" });
+populate(target, { DB_HOST: "localhost" }, { debug: true });
+populate(target, { DB_HOST: "localhost" }, { override: true });
+populate(target, { DB_HOST: "localhost" }, { debug: true, override: false });


### PR DESCRIPTION
## Problem

The `populate()` function accepts three arguments: `processEnv`, `parsed`, and `options`. Its implementation only reads `debug` and `override` from `options` — exactly the two fields defined in `DotenvPopulateOptions`.

However, the type signature in `lib/main.d.ts` typed the third argument as `DotenvConfigOptions`, which is the broader interface that also includes `path`, `encoding`, `quiet`, `processEnv`, and `DOTENV_KEY`. None of those extra fields do anything inside `populate()`.

This meant TypeScript users got misleading IntelliSense: autocomplete would suggest `quiet`, `path`, `encoding`, etc. as valid options for `populate()`, when they are silently ignored at runtime.

There was also a secondary issue: the JSDoc `@param options` example on `populate()` showed `{ quiet: false, debug: true, override: false }`, referencing `quiet` which is not part of `DotenvPopulateOptions` and does nothing in `populate()`.

## Changes

- **`lib/main.d.ts`**: Change `populate()` third argument from `DotenvConfigOptions` to `DotenvPopulateOptions`
- **`lib/main.d.ts`**: Fix `@param options` JSDoc example to remove `quiet` and only show `debug`/`override`
- **`lib/main.d.ts`**: Fix the JSDoc examples inside `DotenvPopulateOptions` fields to reference `populate()` instead of `config()`
- **`tests/types/test.ts`**: Add `populate()` usage to the TypeScript type test so the `dts-check` script covers this function going forward

## Verification

```
npm test  # all 194 tests pass, lint clean, dts-check passes
```

The `DotenvPopulateOptions` interface already existed in the type file — it just wasn't being used for `populate()`. This change connects the two correctly.