### PR TITLE
Added important information indicating that dotenv is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Dotenv is a zero-dependency module that loads environment variables from a `.env
 
 [Watch the tutorial](https://www.youtube.com/watch?v=YtkZR0NFd1g)
 
-## Deprecated
+### Deprecated
 `dotenv` is deprecated. migrate to `process.loadEnvFile()`. Thank the Node.js developers for implementing this.
 
 &nbsp;

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Dotenv is a zero-dependency module that loads environment variables from a `.env
 
 [Watch the tutorial](https://www.youtube.com/watch?v=YtkZR0NFd1g)
 
+## Deprecated
+`dotenv` is deprecated. migrate to `process.loadEnvFile()`. Thank the Node.js developers for implementing this.
+
 &nbsp;
 
 ## Usage


### PR DESCRIPTION
This PR adds a note in `README.md` stating that dotenv is deprecated and that migrating to `process.loadEnvFile()` is recommended.
This was discussed in https://github.com/motdotla/dotenv/issues/1007

<img width="924" height="602" alt="{23A0E32C-BFF6-4640-AB4B-74F4E0C73089}" src="https://github.com/user-attachments/assets/960f9b9c-e733-43a2-8f9c-f815344f6ade" />