### PR TITLE
Set lead and maintainer logins to fork owner

### DIFF
--- a/PREPARE.md
+++ b/PREPARE.md
@@ -1,0 +1,70 @@
+# Evaluation Setup
+
+This file is outside the editable surface. It defines how results are judged. Agents cannot modify the evaluator or the scoring logic — the evaluation is the trust boundary.
+
+The primary metric is `dotenv.parse` throughput. The secondary gate is the tap test suite: a run is only scored if every test passes, which prevents throughput "wins" that silently break parsing semantics.
+
+eval_cores: 1
+eval_memory_gb: 1.0
+
+## Setup
+
+Requires Node.js >= 18 and npm. From a clean checkout:
+
+```bash
+npm ci
+```
+
+This installs the exact dev-dependency tree from `package-lock.json` (tap, standard, sinon, typescript, etc.). No network access is required at benchmark time.
+
+## Run command
+
+Runs the full tap test suite as a correctness gate, then benchmarks `parse` on `tests/.env` and prints `METRIC=<ops_per_sec>`.
+
+```bash
+npm test >/dev/null 2>&1 || { echo "METRIC=0"; echo "FAIL: npm test did not pass"; exit 1; }
+
+node -e '
+const fs = require("fs");
+const path = require("path");
+const { parse } = require("./lib/main.js");
+const src = fs.readFileSync(path.join("tests", ".env"));
+
+// Warmup — let V8 optimize.
+for (let i = 0; i < 5000; i++) parse(src);
+
+// Measure: run for ~3 seconds of wall time, report ops/sec as the median
+// of 5 independent trials to reduce noise.
+const TRIAL_MS = 3000;
+const trials = [];
+for (let t = 0; t < 5; t++) {
+  let ops = 0;
+  const start = process.hrtime.bigint();
+  const deadline = start + BigInt(TRIAL_MS) * 1000000n;
+  while (process.hrtime.bigint() < deadline) {
+    for (let i = 0; i < 1000; i++) parse(src);
+    ops += 1000;
+  }
+  const elapsedNs = Number(process.hrtime.bigint() - start);
+  trials.push(ops / (elapsedNs / 1e9));
+}
+trials.sort((a, b) => a - b);
+const median = trials[Math.floor(trials.length / 2)];
+console.log("trials=" + trials.map(n => n.toFixed(0)).join(","));
+console.log("METRIC=" + median.toFixed(2));
+'
+```
+
+## Output format
+
+The benchmark must print `METRIC=<number>` to stdout. Higher is better (ops/sec).
+
+## Metric parsing
+
+The CLI looks for `METRIC=<number>` or `ops_per_sec=<number>` in the output. Only the final `METRIC=` line is scored; the `trials=` line is diagnostic.
+
+## Ground truth
+
+The metric is the median of 5 × 3-second trials of `dotenv.parse(src)` where `src` is the 43-line, ~2 KB `tests/.env` fixture shipped in this repo. The fixture exercises the full grammar: unquoted values, single/double/backtick-quoted strings, escaped newlines, inline comments, `export` prefixes, and empty values. The `tests/.env` file is part of the protected evaluation surface and must not change — a change there would invalidate the baseline.
+
+Correctness is gated by `npm test`, which runs the tap suite in `tests/**/*.js` (parse, config, populate, vault, CLI options, multiline, decrypt). If any test fails, the run is scored `METRIC=0` and marked failed.

--- a/PROGRAM.md
+++ b/PROGRAM.md
@@ -1,8 +1,8 @@
 # Research Program
 
 cli_version: 0.5.2
-lead_github_login: motdotla
-maintainer_github_login: motdotla
+lead_github_login: alanzabihi
+maintainer_github_login: alanzabihi
 metric_tolerance: 0.01
 metric_direction: higher_is_better
 required_confirmations: 0

--- a/PROGRAM.md
+++ b/PROGRAM.md
@@ -1,0 +1,50 @@
+# Research Program
+
+cli_version: 0.5.2
+lead_github_login: motdotla
+maintainer_github_login: motdotla
+metric_tolerance: 0.01
+metric_direction: higher_is_better
+required_confirmations: 0
+auto_approve: true
+min_queue_depth: 5
+assignment_timeout: 24h
+
+## Goal
+
+Increase throughput (ops/sec) of `dotenv.parse` on the bundled `tests/.env` fixture, while keeping the full `npm test` suite passing. Baseline is measured by the benchmark in PREPARE.md; a run only counts if every tap test passes.
+
+## What you CAN modify
+
+- `lib/**` — parser, config loader, env/CLI option shims, type declarations
+- `config.js`, `config.d.ts` — preload entry point
+
+## What you CANNOT modify
+
+- `PROGRAM.md` — research program specification
+- `PREPARE.md` — evaluation setup and trust boundary
+- `.polyresearch/`, `.polyresearch-node.toml` — runtime directory and node config
+- `tests/**` — test suite and fixtures (the correctness gate)
+- `package.json`, `package-lock.json` — dependency and script definitions
+- `.github/**` — CI configuration
+- `README.md`, `README-es.md`, `CHANGELOG.md`, `CONTRIBUTING.md`, `SECURITY.md`, `LICENSE` — docs and metadata
+- `results.tsv` — experiment history (append-only, managed by the CLI)
+- Any file that defines the evaluation harness or scoring logic
+
+## Constraints
+
+- All changes must pass the evaluation harness defined in PREPARE.md.
+- Each experiment should be atomic and independently verifiable.
+- All else being equal, simpler is better. A small improvement that adds ugly complexity is not worth keeping. Removing code and getting equal or better results is a great outcome.
+- If a run crashes, use judgment: fix trivial bugs (typos, missing imports) and re-run. If the idea is fundamentally broken, skip it and move on.
+- Document what you tried and what you observed in the attempt summary.
+
+## Strategy hints
+
+- Read the full codebase before your first experiment. Understand what you are working with.
+- Start with the lowest-hanging fruit.
+- Measure before and after every change.
+- Read results.tsv to learn from history. Do not repeat approaches that already failed.
+- If an approach does not show improvement after reasonable effort, release and move on.
+- Try combining ideas from previous near-misses.
+- If you are stuck, try something more radical. Re-read the source for new angles.

--- a/results.tsv
+++ b/results.tsv
@@ -1,0 +1,1 @@
+thesis	attempt	metric	baseline	status	summary


### PR DESCRIPTION
PROGRAM.md still had `motdotla` (upstream owner) as `lead_github_login` and `maintainer_github_login`. This caused `polyresearch lead` to reject with a lead-only guard error since the fork's GitHub login is `alanzabihi`.