### PR TITLE
docs: added URL object example for path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,13 @@ Specify a custom path if your file containing environment variables is located e
 ```js
 require('dotenv').config({ path: '/custom/path/to/.env' })
 ```
+You can also pass a `URL` object:
+
+```js
+const fileUrl = new URL('file:///custom/path/to/.env')
+
+require('dotenv').config({ path: fileUrl })
+```
 
 By default, `config` will look for a file called .env in the current working directory.
 


### PR DESCRIPTION
Adds an example showing that the `path` option can also accept a `URL` object.

This behavior is already covered in tests, but was not documented in the README