### PR TITLE
fix: preserve env values when preload override is false

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -370,7 +370,7 @@ function decrypt (encrypted, keyStr) {
 // Populate process.env with parsed values
 function populate (processEnv, parsed, options = {}) {
   const debug = Boolean(options && options.debug)
-  const override = Boolean(options && options.override)
+  const override = parseBoolean(options && options.override)
   const populated = {}
 
   if (typeof parsed !== 'object') {

--- a/tests/test-config-cli.js
+++ b/tests/test-config-cli.js
@@ -21,7 +21,7 @@ function spawn (cmd, options = {}) {
   return stdout
 }
 
-t.plan(3)
+t.plan(6)
 
 // dotenv/config enables preloading
 t.equal(
@@ -34,6 +34,69 @@ t.equal(
       'dotenv_config_encoding=utf8',
       'dotenv_config_path=./tests/.env'
     ]
+  ),
+  'basic\n'
+)
+
+// dotenv/config preserves existing values when env override option is false
+t.equal(
+  spawn(
+    [
+      '-r',
+      './config',
+      '-e',
+      'console.log(process.env.BASIC)'
+    ],
+    {
+      env: {
+        BASIC: 'existing',
+        DOTENV_CONFIG_PATH: './tests/.env',
+        DOTENV_CONFIG_QUIET: 'true',
+        DOTENV_CONFIG_OVERRIDE: 'false'
+      }
+    }
+  ),
+  'existing\n'
+)
+
+// dotenv/config preserves existing values when CLI override option is false
+t.equal(
+  spawn(
+    [
+      '-r',
+      './config',
+      '-e',
+      'console.log(process.env.BASIC)',
+      'dotenv_config_path=./tests/.env',
+      'dotenv_config_quiet=true',
+      'dotenv_config_override=false'
+    ],
+    {
+      env: {
+        BASIC: 'existing'
+      }
+    }
+  ),
+  'existing\n'
+)
+
+// dotenv/config still overwrites existing values when env override option is true
+t.equal(
+  spawn(
+    [
+      '-r',
+      './config',
+      '-e',
+      'console.log(process.env.BASIC)'
+    ],
+    {
+      env: {
+        BASIC: 'existing',
+        DOTENV_CONFIG_PATH: './tests/.env',
+        DOTENV_CONFIG_QUIET: 'true',
+        DOTENV_CONFIG_OVERRIDE: 'true'
+      }
+    }
   ),
   'basic\n'
 )


### PR DESCRIPTION
## Summary

This updates preload override handling so explicit string false values are treated the same as the documented boolean false case.

It also adds focused coverage for environment and CLI preload options.

## What changed

- `lib/main.js` now uses the existing boolean parser when deciding whether   `populate` should overwrite existing values.
- `tests/test-config-cli.js` now covers:
  - `DOTENV_CONFIG_OVERRIDE=false` preserving an existing value.
  - `dotenv_config_override=false` preserving an existing value.
  - `DOTENV_CONFIG_OVERRIDE=true` continuing to overwrite an existing value.

## Why

Preload options arrive as strings from environment variables and CLI arguments. The existing parser already treats strings such as `false`, `0`, `no`, `off`, and an empty string as false for other boolean options.

Applying that same parser to `override` makes preload behavior line up with the documented default while keeping string `true` behavior unchanged.

## Tests run

- [x] Focused Docker validation with `npm ci --ignore-scripts`:
  `tests/test-config-cli.js`
  - Result: 6 total, 6 pass.
- [x] Broader Docker validation subset with `npm ci --ignore-scripts`:
  `tests/test-config-cli.js`, `tests/test-config.js`,
  `tests/test-populate.js`, `tests/test-env-options.js`,
  `tests/test-cli-options.js`
  - Result: 89 total, 89 pass.

## Risk/compatibility notes

- This is a small behavior change for string-valued `override` options.
- String `true` still enables override.
- Boolean `true` and boolean `false` behavior remains consistent with the documented option.
- Users who intentionally relied on any non-empty `override` string enabling override would see `false`, `0`, `no`, `off`, and empty-string values treated   as false.
- The option extraction helpers continue to return string values; normalization remains at the point where overwrite behavior is decided.

## Maintainer notes

- I kept this change scoped to `populate` so env and CLI option parsing behavior remains unchanged.
- I added coverage at the preload level because that is where string-valued options are user-visible.
- Happy to adjust the test placement if a lower-level `populate` test would be preferred.