### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ pnpm add dotenv
 ```
 
 </details>
+<details><summary>deno</summary><br>
+
+```sh
+deno add dotenv
+```
+
+</details>
 <details><summary>Monorepos</summary><br>
 
 For monorepos with a structure like `apps/backend/app.js`, put it the `.env` file in the root of the folder where your `app.js` process runs.


### PR DESCRIPTION
👋 Bartek from the Deno team here. Thanks for dotenv.

The Advanced section has per-package-manager `<details>` blocks for bun / yarn / pnpm. This adds a matching `deno` one, since Deno is a drop-in replacement for npm these days:

```sh
deno add dotenv
```

Docs-only change that mirrors the existing blocks. Totally fine to close this if you'd prefer not to. Happy to adjust.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._
