### PR TITLE
Update repository metadata URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/motdotla/dotenv.git"
+    "url": "git+https://github.com/motdotla/dotenv.git"
   },
   "homepage": "https://github.com/motdotla/dotenv#readme",
   "funding": "https://dotenvx.com",


### PR DESCRIPTION
Summary:
- update the package repository URL from git:// to git+https://
- keep the existing GitHub repository target unchanged

Verification:
- parsed package.json with Node and confirmed repository.url
- ran git diff --check

This is a metadata-only change.