### PR TITLE
fix: do not strip boundary quotes from unquoted values

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -38,6 +38,12 @@ function dim (text) {
 
 const LINE = /(?:^|^)\s*(?:export\s+)?([\w.-]+)(?:\s*=\s*?|:\s+?)(\s*'(?:\\'|[^'])*'|\s*"(?:\\"|[^"])*"|\s*`(?:\\`|[^`])*`|[^#\r\n]+)?\s*(?:#.*)?(?:$|$)/mg
 
+// Matches a value that is a single, fully wrapped quoted token (the same
+// single/double/backtick alternatives the LINE regex allows). Used to decide
+// whether the surrounding quotes are an actual wrapper to strip, versus quote
+// characters that merely happen to start and end an unquoted value.
+const QUOTED = /^'(?:\\'|[^'])*'$|^"(?:\\"|[^"])*"$|^`(?:\\`|[^`])*`$/
+
 // Parse src into an Object
 function parse (src) {
   const obj = {}
@@ -58,11 +64,18 @@ function parse (src) {
     // Remove whitespace
     value = value.trim()
 
+    // Only treat the value as quoted when it is a fully wrapped quoted token,
+    // not merely an unquoted value that happens to start and end with a quote
+    // (e.g. "a":"b" keeps its boundary quotes - inner quotes are maintained).
+    const quoted = QUOTED.test(value)
+
     // Check if double quoted
-    const maybeQuote = value[0]
+    const maybeQuote = quoted ? value[0] : ''
 
     // Remove surrounding quotes
-    value = value.replace(/^(['"`])([\s\S]*)\1$/mg, '$2')
+    if (quoted) {
+      value = value.replace(/^(['"`])([\s\S]*)\1$/mg, '$2')
+    }
 
     // Expand newlines if double quoted
     if (maybeQuote === '"') {

--- a/tests/.env
+++ b/tests/.env
@@ -31,6 +31,7 @@ INLINE_COMMENTS_BACKTICKS=`inline comments outside of #backticks` # work
 INLINE_COMMENTS_SPACE=inline comments start with a#number sign. no space required.
 EQUAL_SIGNS=equals==
 RETAIN_INNER_QUOTES={"foo": "bar"}
+RETAIN_BOUNDARY_QUOTES_UNQUOTED="a":"b"
 RETAIN_INNER_QUOTES_AS_STRING='{"foo": "bar"}'
 RETAIN_INNER_QUOTES_AS_BACKTICKS=`{"foo": "bar's"}`
 TRIM_SPACE_FROM_UNQUOTED=    some spaced out string

--- a/tests/test-parse.js
+++ b/tests/test-parse.js
@@ -69,6 +69,8 @@ t.equal(parsed.EQUAL_SIGNS, 'equals==', 'respects equals signs in values')
 
 t.equal(parsed.RETAIN_INNER_QUOTES, '{"foo": "bar"}', 'retains inner quotes')
 
+t.equal(parsed.RETAIN_BOUNDARY_QUOTES_UNQUOTED, '"a":"b"', 'does not strip boundary quotes from an unquoted value')
+
 t.equal(parsed.RETAIN_INNER_QUOTES_AS_STRING, '{"foo": "bar"}', 'retains inner quotes')
 
 t.equal(parsed.RETAIN_INNER_QUOTES_AS_BACKTICKS, '{"foo": "bar\'s"}', 'retains inner quotes')


### PR DESCRIPTION
## The bug

An unquoted value that happens to start and end with the same quote character has those boundary quotes stripped:

```ini
JSON="a":"b"   # parsed as  a":"b   (expected "a":"b")
K="x"y"z"      # parsed as  x"y"z   (expected "x"y"z")
```

```js
require('dotenv').parse('JSON="a":"b"')
// => { JSON: 'a":"b' }   wrong, lost the boundary quotes
```

## Why this is wrong

The README documents that inner quotes are maintained (line 447, "think JSON"):

> inner quotes are maintained (think JSON) (`JSON={"foo": "bar"}` becomes `{JSON:"{\"foo\": \"bar\"}"`)

`"a":"b"` is the same shape: a value whose quote characters are content, not a wrapper. It only differs in that its quote characters land on the boundary. The first and last `"` are part of the value, so they should be kept.

This also matters for shell / dotenvx interop. In a POSIX shell, `JSON="a":"b"` assigns the literal `a:b` (each `"..."` is a separate quoted span the shell concatenates), and dotenvx-style consumers expect the raw token to round-trip. Silently deleting the outer quotes produces a value (`a":"b`) that matches neither the shell result nor the documented JSON-style behavior.

## Root cause

The value `"a":"b"` cannot match the double-quoted `LINE` alternative `"(?:\\"|[^"])*"` because the unescaped inner `"` blocks a clean wrap, so it falls through to the unquoted alternative `[^#\r\n]+` and is captured raw.

The surrounding-quote strip then runs unconditionally:

```js
value = value.replace(/^(['"`])([\s\S]*)\1$/mg, '$2')
```

That regex fires on any value whose first and last characters are the same quote char, without verifying the value was actually captured as a wrapped quoted token. So an unquoted value gets its boundary quotes deleted.

## The fix

Strip the surrounding quotes (and run the double-quote `\n`/`\r` expansion) only when the value is a fully wrapped quoted token, matched with the same single/double/backtick alternatives the `LINE` regex itself allows:

```js
const QUOTED = /^'(?:\\'|[^'])*'$|^"(?:\\"|[^"])*"$|^`(?:\\`|[^`])*`$/
// ...
const quoted = QUOTED.test(value)
const maybeQuote = quoted ? value[0] : ''
if (quoted) {
  value = value.replace(/^(['"`])([\s\S]*)\1$/mg, '$2')
}
```

A genuinely quoted value (`"x"`, `'x'`, `` `x` ``) still matches `QUOTED` and is stripped exactly as before. An unquoted value whose boundary characters happen to be quotes does not match, so its quotes are preserved.

## Red -> green

Added a fixture line `RETAIN_BOUNDARY_QUOTES_UNQUOTED="a":"b"` to `tests/.env` and an assertion in `tests/test-parse.js`:

```js
t.equal(parsed.RETAIN_BOUNDARY_QUOTES_UNQUOTED, '"a":"b"', 'does not strip boundary quotes from an unquoted value')
```

Fails before the fix (parses to `a":"b`), passes after.

Full suite green: `{ total: 200, pass: 200 }` (lint + dts-check + all parse / multiline / config / populate tests, including every existing single/double/backtick quote, `\n` expansion, and the `RETAIN_INNER_QUOTES` fixtures).
