### PR TITLE
fix: treat \\ as an escape pair in the fast parser

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -146,13 +146,22 @@ function parseFast (src) {
       let j = vStart
       while (j < len) {
         const cc = str.charCodeAt(j)
-        if (cc === 92 /* \ */ && j + 1 < len && str.charCodeAt(j + 1) === quote) {
-          j += 2
-        } else if (cc === quote) {
-          break
-        } else {
-          j++
+        // a backslash consumes the next character when it escapes the quote (\") or
+        // another backslash (\\). Without the \\ case the second backslash of a pair
+        // is left free to escape a following closing quote, so a value ending in an
+        // escaped backslash — VAR="C:\\dir\\" — runs past its own closing quote and
+        // swallows the rest of the file.
+        if (cc === 92 /* \ */ && j + 1 < len) {
+          const nc = str.charCodeAt(j + 1)
+          if (nc === quote || nc === 92 /* \ */) {
+            j += 2
+            continue
+          }
         }
+        if (cc === quote) {
+          break
+        }
+        j++
       }
       if (j >= len) {
         // unterminated quote — fall back to unquoted-from-here semantics

--- a/tests/test-parse-fast.js
+++ b/tests/test-parse-fast.js
@@ -67,6 +67,34 @@ t.test('fast parse matches classic parse for a leading UTF-8 BOM', ct => {
   ct.end()
 })
 
+t.test('fast parse matches classic parse for an escaped backslash before the closing quote', ct => {
+  const cases = [
+    'KEY="\\\\"',
+    'KEY="\\\\"\nNEXT=ok\n',
+    "KEY='\\\\'\nNEXT=ok\n",
+    'KEY=`\\\\`\nNEXT=ok\n',
+    'WINDIR="C:\\\\Users\\\\me\\\\"\nAPI_KEY=secret\nPORT=3000\n',
+    'KEY="a\\\\b"\nNEXT=ok\n',
+    'KEY="\\\\\\\\"\nNEXT=ok\n',
+    'A="\\\\"\nB=plain\nC="quoted"\nD=last\n'
+  ]
+
+  for (const src of cases) {
+    assertSameParse(ct, src, JSON.stringify(src))
+  }
+
+  // pin the behaviour, so the two parsers can't agree by both being wrong.
+  // dotenv does not unescape \\, so the value keeps both backslashes — the point
+  // is that the value ends at its own closing quote and the later keys survive.
+  ct.same(dotenv.parse('A="\\\\"\nB=plain\nC="quoted"\nD=last\n', { fast: true }), {
+    A: '\\\\',
+    B: 'plain',
+    C: 'quoted',
+    D: 'last'
+  })
+  ct.end()
+})
+
 t.test('config({ fast: true }) reads a .env written with a BOM', ct => {
   const processEnv = {}
   const result = dotenv.config({


### PR DESCRIPTION
In the `{ fast: true }` parser, a double-quoted value whose contents end in an escaped backslash runs past its own closing quote and swallows the rest of the file. Subsequent variables silently disappear.

```js
const src = 'A="\\\\"\nB=plain\nC="quoted"\nD=last\n'

dotenv.parse(src)                   // { A: '\\\\', B: 'plain', C: 'quoted', D: 'last' }
dotenv.parse(src, { fast: true })   // { A: '\\\\"\nB=plain\nC=',                D: 'last' }
//                                     ^ B and C are gone
```

A realistic trigger is a Windows path, since `.env` files often escape the separators:

```ini
WINDIR="C:\\Users\\me\\"
API_KEY=secret
PORT=3000
```

On `master` that yields `WINDIR: '"C:\\Users\\me\\"'` — quotes included — because the scan runs to EOF and falls into the unterminated-quote path. `API_KEY` and `PORT` survive only because nothing later in the file is quoted; add one quoted value below and the lines in between are swallowed instead, as in the first example. Either way there is no error.

### Cause

The closing-quote scan treats a backslash as escaping only the quote character:

```js
if (cc === 92 /* \ */ && j + 1 < len && str.charCodeAt(j + 1) === quote) {
  j += 2
}
```

There is no case for `\\`, so in the sequence `\` `\` `"` the first backslash is consumed as an ordinary character and the **second** one is left to pair with the closing quote. The scan skips over the quote that should have ended the value and keeps going until it finds the next quote in the file, or hits EOF and falls into the unterminated-quote path (which is where the stray `"` in `A`'s value above comes from).

The classic regex avoids this by backtracking, so the two parsers disagree.

### Fix

Let a backslash consume the next character when it escapes either the quote or another backslash, so the second backslash of a pair can no longer escape the closing quote. Values are unchanged — `\\` is still not unescaped, matching the classic parser.

### Verification

I found this by differentially fuzzing `parse(src)` against `parse(src, { fast: true })` over generated well-formed `.env` content. Before the change, 15,299 of 400,000 inputs diverged across 21 distinct failure classes; every one traced back to this single cause. After it, 0 of 400,000 diverge.

`npm test` is green (190 pass, 1 pre-existing skip) and `npm run lint` is clean. The new test cases fail on `master` and pass with the fix; `KEY="a\\b"` is included as a control that passes either way.

### One related case left alone

An **odd** number of backslashes before the closing quote still diverges, e.g. `WINDIR="C:\Users\me\"` (single separators, no escaping):

```js
dotenv.parse('K="a\\"\nN=ok\n')                 // { K: 'a\\', N: 'ok' }
dotenv.parse('K="a\\"\nN=ok\n', { fast: true }) // { K: '"a\\"', N: 'ok' }
```

Matching the classic parser there needs more than escape tracking — its regex picks the closing quote using the rest of the line (`\s*(?:#.*)?$`), and reproducing that in a forward scan is a bigger change than this one. I left it out rather than half-fix it, and I'm happy to follow up separately if you'd like it addressed.
